### PR TITLE
Support running arbitrary scripts on test case start and end

### DIFF
--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -105,6 +105,9 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSNumber *deleteTimeout;
 @property (nonatomic) BOOL keepIndividualTestReports;
 
+@property (nonatomic) NSString *testStartedScriptFilePath;
+@property (nonatomic) NSString *testEndedScriptFilePath;
+
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;
 @property (nonatomic, strong) NSDictionary<NSString *, BPTestPlan *> *tests;

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -266,23 +266,10 @@
 }
 
 - (void)runScriptFile:(NSString *)scriptFilePath {
-    NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath:scriptFilePath];
-    NSMutableDictionary *env = [[NSMutableDictionary alloc] init];
-    [env addEntriesFromDictionary:[[NSProcessInfo processInfo] environment]];
-    [env setObject:[NSString stringWithFormat:@"%@", self.device.UDID.UUIDString] forKey:@"BP_DEVICE_ID"];
-    [env setObject:[NSString stringWithFormat:@"%@", self.device.devicePath] forKey:@"BP_DEVICE_PATH"];
-    [task setEnvironment:env];
-
-    [task launch];
-    [task waitUntilExit];
-    int status = [task terminationStatus];
-    [BPUtils printInfo:INFO withString:@"Script (%@) has finished with exit code %d.",
-         scriptFilePath, [task terminationStatus]];
-
-    if (status != 0) {
-        [BPUtils printInfo:ERROR withString:@"Failed running script: %@", scriptFilePath];
-    }
+    [BPUtils runScriptFile:scriptFilePath withEnv:@{
+        @"BP_DEVICE_ID": self.device.UDID.UUIDString,
+        @"BP_DEVICE_PATH": self.device.devicePath,
+    }];
 }
 
 - (BOOL)useSimulatorWithDeviceUDID:(NSUUID *)deviceUDID {

--- a/bp/src/BPUtils.h
+++ b/bp/src/BPUtils.h
@@ -203,4 +203,12 @@ typedef BOOL (^BPRunBlock)(void);
                                                                     testTimes:(NSDictionary<NSString *,NSNumber *> *)testTimes
                                                                andXCTestFiles:(NSArray<BPXCTestFile *> *)xcTestFiles;
 
+/*!
+ * @discussion Runs a custom script on the host machine.
+ * @param scriptFilePath The path to the script file tobe executed
+ * @param env The additional enviornment parameters that will be passed to the script
+ * @
+ */
++ (void)runScriptFile:(NSString *)scriptFilePath withEnv:(NSDictionary *)env;
+
 @end

--- a/bp/src/BPUtils.m
+++ b/bp/src/BPUtils.m
@@ -431,4 +431,26 @@ static BOOL quiet = NO;
     return totalTime;
 }
 
++ (void)runScriptFile:(NSString *)scriptFilePath withEnv:(NSDictionary *)env {
+    NSTask *task = [[NSTask alloc] init];
+
+    task.launchPath = scriptFilePath;
+    // NOTE:(bogo) make CWD a parent path of the script for sane... scripting
+    task.currentDirectoryPath = scriptFilePath.stringByDeletingLastPathComponent;
+
+    NSMutableDictionary *mutableEnv = [NSProcessInfo.processInfo.environment mutableCopy];
+    [mutableEnv addEntriesFromDictionary:env];
+    [task setEnvironment:mutableEnv];
+
+    [task launch];
+    [task waitUntilExit];
+    int status = [task terminationStatus];
+    [BPUtils printInfo:INFO withString:@"Script (%@) has finished with exit code %d.",
+         scriptFilePath, [task terminationStatus]];
+
+    if (status != 0) {
+        [BPUtils printInfo:ERROR withString:@"Failed running script: %@", scriptFilePath];
+    }
+}
+
 @end

--- a/bp/src/SimulatorMonitor.m
+++ b/bp/src/SimulatorMonitor.m
@@ -282,6 +282,10 @@
 }
 
 - (void)runScriptFile:(NSString *)scriptFilePath state:(NSString *)state {
+    if (scriptFilePath == nil) {
+        return;
+    }
+    
     [BPUtils runScriptFile:scriptFilePath withEnv:@{
         @"BP_TEST_STATE": state,
         @"BP_TEST_SUITE": self.currentClassName ?: self.previousClassName,


### PR DESCRIPTION
Resolves #122 and #385.

As we are working on integrating Bluepill into our CI, we realized we need to get more information out of the tests than Bluepill can currently provide. In our case, those are:
 1. screen recordings of failed tests;
 1. system logs for apps under test.

Since such features are heavily use-case dependent, they probably should not be part of the main Bluepill distribution - but they are easily scriptable, given the correct hooks. This PR adds ability to execute arbitrary scripts at the beginning and end of each test case.

Since I'm pretty new to the Bluepill codebase, I am not sure I am hanging the scripts off in the best possible place. (currently the only place "aware" of individual test cases is the `SimulatorMonitor`) Also, would appreciate a look on whether I'm using the configuration parameters correctly. Any feedback is welcome!

For the sake of completeness, after merging this PR, one could record videos and grab os_logs as follows:

```bash
#!/bin/bash
# test_started.sh

tmp_dir=/tmp/$BP_SIMULATOR_UDID
artifact_path=../../artifacts/$BP_TEST_SUITE-$BP_TEST_CASE-$BP_ATTEMPT_NUMBER
mkdir -p $tmp_dir

xcrun_pidfile=$tmp_dir/xcrun.pid
log_pidfile=$tmp_dir/log.pid

app_name=$(
    case $BP_HOST_BUNDLE_ID in
        ("com.getdropbox.DropboxUITests.xctrunner") echo "Dropbox.app" ;;
        (*) echo $BP_HOST_BUNDLE_ID ;;
    esac
)

predicate="(processImagePath contains \"$app_name\" AND senderImagePath contains \"CoreFoundation\") OR (senderImagePath contains \"$app_name\")"

log stream --predicate "$predicate" --style=compact > $artifact_path.log &
echo $! > $log_pidfile

xcrun simctl io $BP_SIMULATOR_UDID recordVideo --codec=h264 $artifact_path.mov &
echo $! > $xcrun_pidfile
```

```bash
#!/bin/bash
# test_ended.sh

TMP_DIR=/tmp/$BP_SIMULATOR_UDID
PIDFILES=(xcrun.pid log.pid)
for pidfile in "${PIDFILES[@]}"; do
    pkill -SIGINT -F $TMP_DIR/$pidfile
    rm $TMP_DIR/$pidfile
done

ARTIFACT_PATH=../../artifacts/$BP_TEST_SUITE-$BP_TEST_CASE-$BP_ATTEMPT_NUMBER
if [ "$BP_TEST_STATE" = "PASSED" ]; then
    rm $ARTIFACT_PATH.*
fi
```