### PR TITLE
[IN PROGRESS] Working on Xcode 12.5 support

### DIFF
--- a/bp/bp.xcodeproj/project.pbxproj
+++ b/bp/bp.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		7ACE1F721DD3D27D00C0FA73 /* WaitTimerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ACE1F711DD3D27D00C0FA73 /* WaitTimerTests.m */; };
 		7ADBB1471DCBBC0E00DC4E8D /* BPTreeAssembler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ADBB1461DCBBC0E00DC4E8D /* BPTreeAssembler.m */; };
 		7ADBB1481DCBDB9300DC4E8D /* BPTreeAssembler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7ADBB1461DCBBC0E00DC4E8D /* BPTreeAssembler.m */; };
+		8AFA37B8264E3B0A00148A94 /* NSString+IdentifierString.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFA37B6264E3B0A00148A94 /* NSString+IdentifierString.m */; };
 		B3103CE8215176EE00C5643C /* BPTestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = BAB24F721DB5DFA200867756 /* BPTestHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3103CEA2151774500C5643C /* BPXCTestFile.m in Headers */ = {isa = PBXBuildFile; fileRef = C41A2C711E0B2497005D9751 /* BPXCTestFile.m */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3103CEB21519FFE00C5643C /* SimulatorHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = BA34F5E21D6D75E30063B17F /* SimulatorHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -186,6 +187,9 @@
 		7DDFED931F8188CC00D1357C /* SimDeviceIOProtocol-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimDeviceIOProtocol-Protocol.h"; sourceTree = "<group>"; };
 		7DDFED941F8188EC00D1357C /* SimDeviceIOPortDescriptorState-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SimDeviceIOPortDescriptorState-Protocol.h"; sourceTree = "<group>"; };
 		7DDFED961F81896C00D1357C /* SimDeviceFramebufferService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimDeviceFramebufferService.h; sourceTree = "<group>"; };
+		8AFA37B5264E3AA800148A94 /* XCTTestIdentifierSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCTTestIdentifierSet.h; sourceTree = "<group>"; };
+		8AFA37B6264E3B0A00148A94 /* NSString+IdentifierString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+IdentifierString.m"; sourceTree = "<group>"; };
+		8AFA37B7264E3B0A00148A94 /* NSString+IdentifierString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+IdentifierString.h"; sourceTree = "<group>"; };
 		B324B91C1F280AD100AAE2BC /* CoreSimulator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSimulator.framework; path = ../../../../../../../Library/Developer/PrivateFrameworks/CoreSimulator.framework; sourceTree = "<group>"; };
 		B368E55A213F8D2E00B4DEA3 /* bplib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = bplib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B368E55C213F8D2E00B4DEA3 /* bplib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bplib.h; sourceTree = "<group>"; };
@@ -351,6 +355,8 @@
 		7A4FB8CC1DF89A790073F268 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				8AFA37B7264E3B0A00148A94 /* NSString+IdentifierString.h */,
+				8AFA37B6264E3B0A00148A94 /* NSString+IdentifierString.m */,
 				C487CB1A226A36F500CC5BC2 /* BPVersion.h */,
 				BA1949341E4AF82F00881887 /* BPTestBundleConnection.h */,
 				BA1949351E4AF82F00881887 /* BPTestBundleConnection.m */,
@@ -493,6 +499,7 @@
 		BA34F5E51D6D78120063B17F /* XCTest */ = {
 			isa = PBXGroup;
 			children = (
+				8AFA37B5264E3AA800148A94 /* XCTTestIdentifierSet.h */,
 				BAFCCA701E37298B00E33C31 /* XCTestDriverInterface-Protocol.h */,
 				BAFCCA711E37298B00E33C31 /* XCTestManager_DaemonConnectionInterface-Protocol.h */,
 				BAFCCA6D1E36EB5500E33C31 /* XCTestManager_IDEInterface-Protocol.h */,
@@ -833,6 +840,7 @@
 				BA944BD01D76A39A00A4BDA3 /* Bluepill.m in Sources */,
 				7A564C0E1DA817DE001BCEC2 /* BPTreeObjects.m in Sources */,
 				7A7901861D5CB679004D4325 /* main.m in Sources */,
+				8AFA37B8264E3B0A00148A94 /* NSString+IdentifierString.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bp/bp.xcodeproj/project.pbxproj
+++ b/bp/bp.xcodeproj/project.pbxproj
@@ -187,6 +187,29 @@
 		7DDFED931F8188CC00D1357C /* SimDeviceIOProtocol-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimDeviceIOProtocol-Protocol.h"; sourceTree = "<group>"; };
 		7DDFED941F8188EC00D1357C /* SimDeviceIOPortDescriptorState-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SimDeviceIOPortDescriptorState-Protocol.h"; sourceTree = "<group>"; };
 		7DDFED961F81896C00D1357C /* SimDeviceFramebufferService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimDeviceFramebufferService.h; sourceTree = "<group>"; };
+		8AA74DF9264E51E80007D53C /* XCActivityRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCActivityRecord.h; sourceTree = "<group>"; };
+		8AA74DFA264E52460007D53C /* XCTMessagingChannel_RunnerToIDE-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_RunnerToIDE-Protocol.h"; sourceTree = "<group>"; };
+		8AA74DFB264E52710007D53C /* XCTMessagingChannel_IDEToRunner-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_IDEToRunner-Protocol.h"; sourceTree = "<group>"; };
+		8AA74DFC264E52850007D53C /* XCTMessagingChannel_DaemonToIDE-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_DaemonToIDE-Protocol.h"; sourceTree = "<group>"; };
+		8AA74DFD264E52850007D53C /* XCTMessagingChannel_IDEToDaemon-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_IDEToDaemon-Protocol.h"; sourceTree = "<group>"; };
+		8AA74DFE264E53200007D53C /* XCTMessagingRole_DebugLogging-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_DebugLogging-Protocol.h"; sourceTree = "<group>"; };
+		8AA74DFF264E53200007D53C /* XCTMessagingRole_CrashReporting-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_CrashReporting-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E00264E53200007D53C /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E01264E532C0007D53C /* _XCTMessaging_VoidProtocol-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "_XCTMessaging_VoidProtocol-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E02264E53490007D53C /* XCTMessagingRole_DiagnosticsCollection-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_DiagnosticsCollection-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E03264E53490007D53C /* XCTMessagingRole_RunnerSessionInitiation-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_RunnerSessionInitiation-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E04264E53490007D53C /* XCTMessagingRole_ControlSessionInitiation-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ControlSessionInitiation-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E05264E53490007D53C /* XCTMessagingRole_UIRecordingControl-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_UIRecordingControl-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E06264E535D0007D53C /* XCTMessagingRole_ProcessMonitoring-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ProcessMonitoring-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E07264E535D0007D53C /* XCTMessagingRole_TestExecution-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TestExecution-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E08264E535D0007D53C /* XCTMessagingRole_TestExecution_Legacy-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TestExecution_Legacy-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E09264E53990007D53C /* XCTMessagingRole_TestReporting-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TestReporting-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0A264E53990007D53C /* XCTMessagingRole_ActivityReporting_Legacy-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ActivityReporting_Legacy-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0B264E53990007D53C /* XCTMessagingRole_PerformanceMeasurementReporting_Legacy-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_PerformanceMeasurementReporting_Legacy-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0C264E53990007D53C /* XCTMessagingRole_ActivityReporting-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ActivityReporting-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0D264E53990007D53C /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0E264E53990007D53C /* XCTMessagingRole_UIAutomation-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_UIAutomation-Protocol.h"; sourceTree = "<group>"; };
+		8AA74E0F264E53990007D53C /* XCTMessagingRole_TestReporting_Legacy-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TestReporting_Legacy-Protocol.h"; sourceTree = "<group>"; };
 		8AFA37B5264E3AA800148A94 /* XCTTestIdentifierSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCTTestIdentifierSet.h; sourceTree = "<group>"; };
 		8AFA37B6264E3B0A00148A94 /* NSString+IdentifierString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+IdentifierString.m"; sourceTree = "<group>"; };
 		8AFA37B7264E3B0A00148A94 /* NSString+IdentifierString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+IdentifierString.h"; sourceTree = "<group>"; };
@@ -297,11 +320,6 @@
 		BAFCCA531E36DBA900E33C31 /* DTXSocketTransport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DTXSocketTransport.h; sourceTree = "<group>"; };
 		BAFCCA541E36DBA900E33C31 /* DTXTransport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DTXTransport.h; sourceTree = "<group>"; };
 		BAFCCA581E36DBA900E33C31 /* NSURLSessionDelegate-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionDelegate-Protocol.h"; sourceTree = "<group>"; };
-		BAFCCA6D1E36EB5500E33C31 /* XCTestManager_IDEInterface-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestManager_IDEInterface-Protocol.h"; sourceTree = "<group>"; };
-		BAFCCA6E1E36EB5500E33C31 /* XCTestManager_ManagerInterface-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestManager_ManagerInterface-Protocol.h"; sourceTree = "<group>"; };
-		BAFCCA6F1E36EB5500E33C31 /* XCTestManager_TestsInterface-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestManager_TestsInterface-Protocol.h"; sourceTree = "<group>"; };
-		BAFCCA701E37298B00E33C31 /* XCTestDriverInterface-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestDriverInterface-Protocol.h"; sourceTree = "<group>"; };
-		BAFCCA711E37298B00E33C31 /* XCTestManager_DaemonConnectionInterface-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTestManager_DaemonConnectionInterface-Protocol.h"; sourceTree = "<group>"; };
 		C41A2C701E0B2497005D9751 /* BPXCTestFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPXCTestFile.h; sourceTree = "<group>"; };
 		C41A2C711E0B2497005D9751 /* BPXCTestFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BPXCTestFile.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		C41A2C731E0B24E8005D9751 /* BPTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPTestCase.h; sourceTree = "<group>"; };
@@ -499,13 +517,31 @@
 		BA34F5E51D6D78120063B17F /* XCTest */ = {
 			isa = PBXGroup;
 			children = (
-				8AFA37B5264E3AA800148A94 /* XCTTestIdentifierSet.h */,
-				BAFCCA701E37298B00E33C31 /* XCTestDriverInterface-Protocol.h */,
-				BAFCCA711E37298B00E33C31 /* XCTestManager_DaemonConnectionInterface-Protocol.h */,
-				BAFCCA6D1E36EB5500E33C31 /* XCTestManager_IDEInterface-Protocol.h */,
-				BAFCCA6E1E36EB5500E33C31 /* XCTestManager_ManagerInterface-Protocol.h */,
-				BAFCCA6F1E36EB5500E33C31 /* XCTestManager_TestsInterface-Protocol.h */,
+				8AA74E0A264E53990007D53C /* XCTMessagingRole_ActivityReporting_Legacy-Protocol.h */,
+				8AA74E0C264E53990007D53C /* XCTMessagingRole_ActivityReporting-Protocol.h */,
+				8AA74E0B264E53990007D53C /* XCTMessagingRole_PerformanceMeasurementReporting_Legacy-Protocol.h */,
+				8AA74E0D264E53990007D53C /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */,
+				8AA74E0F264E53990007D53C /* XCTMessagingRole_TestReporting_Legacy-Protocol.h */,
+				8AA74E09264E53990007D53C /* XCTMessagingRole_TestReporting-Protocol.h */,
+				8AA74E0E264E53990007D53C /* XCTMessagingRole_UIAutomation-Protocol.h */,
+				8AA74E06264E535D0007D53C /* XCTMessagingRole_ProcessMonitoring-Protocol.h */,
+				8AA74E08264E535D0007D53C /* XCTMessagingRole_TestExecution_Legacy-Protocol.h */,
+				8AA74E07264E535D0007D53C /* XCTMessagingRole_TestExecution-Protocol.h */,
+				8AA74E04264E53490007D53C /* XCTMessagingRole_ControlSessionInitiation-Protocol.h */,
+				8AA74E02264E53490007D53C /* XCTMessagingRole_DiagnosticsCollection-Protocol.h */,
+				8AA74E03264E53490007D53C /* XCTMessagingRole_RunnerSessionInitiation-Protocol.h */,
+				8AA74E05264E53490007D53C /* XCTMessagingRole_UIRecordingControl-Protocol.h */,
+				8AA74DFF264E53200007D53C /* XCTMessagingRole_CrashReporting-Protocol.h */,
+				8AA74DFE264E53200007D53C /* XCTMessagingRole_DebugLogging-Protocol.h */,
+				8AA74E00264E53200007D53C /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */,
+				8AA74E01264E532C0007D53C /* _XCTMessaging_VoidProtocol-Protocol.h */,
+				8AA74DFC264E52850007D53C /* XCTMessagingChannel_DaemonToIDE-Protocol.h */,
+				8AA74DFD264E52850007D53C /* XCTMessagingChannel_IDEToDaemon-Protocol.h */,
+				8AA74DFB264E52710007D53C /* XCTMessagingChannel_IDEToRunner-Protocol.h */,
+				8AA74DFA264E52460007D53C /* XCTMessagingChannel_RunnerToIDE-Protocol.h */,
+				8AA74DF9264E51E80007D53C /* XCActivityRecord.h */,
 				BA34F5E61D6D78120063B17F /* XCTestConfiguration.h */,
+				8AFA37B5264E3AA800148A94 /* XCTTestIdentifierSet.h */,
 			);
 			path = XCTest;
 			sourceTree = "<group>";

--- a/bp/src/BPTestBundleConnection.h
+++ b/bp/src/BPTestBundleConnection.h
@@ -10,7 +10,7 @@
 #import "BPExecutionContext.h"
 #import "BPSimulator.h"
 
-// This is a small subset of XCTMessagingChannel_IDEToRunner protocol
+// This is a small subset of XCTMessagingChannel_RunnerToIDE protocol
 @protocol BPTestBundleConnectionDelegate <NSObject>
 - (void)_XCT_launchProcessWithPath:(NSString *)path bundleID:(NSString *)bundleID arguments:(NSArray *)arguments environmentVariables:(NSDictionary *)environment;
 @end

--- a/bp/src/BPTestBundleConnection.m
+++ b/bp/src/BPTestBundleConnection.m
@@ -41,7 +41,7 @@
 
 static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
-@interface BPTestBundleConnection()<XCTMessagingChannel_IDEToRunner>
+@interface BPTestBundleConnection()<XCTMessagingChannel_RunnerToIDE>
 
 @property (atomic, nullable, strong) id<XCTMessagingChannel_IDEToRunner> testBundleProxy;
 @property (atomic, nullable, strong, readwrite) DTXConnection *testBundleConnection;
@@ -93,8 +93,8 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
             [BPUtils printInfo:INFO withString:@"DTXConnection disconnected."];
         }];
         [connection
-         handleProxyRequestForInterface:@protocol(XCTMessagingChannel_IDEToRunner)
-         peerInterface:@protocol(XCTMessagingChannel_RunnerToIDE)
+         handleProxyRequestForInterface:@protocol(XCTMessagingChannel_RunnerToIDE)
+         peerInterface:@protocol(XCTMessagingChannel_IDEToRunner)
          handler:^(DTXProxyChannel *channel){
              [BPUtils printInfo:INFO withString:@"Got proxy channel request from test bundle"];
              [channel setExportedObject:self queue:dispatch_get_main_queue()];
@@ -107,7 +107,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
         dispatch_async(dispatch_get_main_queue(), ^{
             DTXProxyChannel *proxyChannel = [self.testBundleConnection
                                              makeProxyChannelWithRemoteInterface:@protocol(XCTMessagingChannel_IDEToDaemon)
-                                             exportedInterface:@protocol(XCTMessagingChannel_IDEToRunner)];
+                                             exportedInterface:@protocol(XCTMessagingChannel_RunnerToIDE)];
             [proxyChannel setExportedObject:self queue:dispatch_get_main_queue()];
             id<XCTMessagingChannel_IDEToDaemon> remoteProxy = (id<XCTMessagingChannel_IDEToDaemon>) proxyChannel.remoteObjectProxy;
 
@@ -192,7 +192,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return transport;
 }
 
-#pragma mark XCTMessagingChannel_RunnerToIDE
+#pragma mark XCTMessagingChannel_IDEToRunner
 
 - (id)_XCT_didBeginExecutingTestPlan {
     [BPUtils printInfo:INFO withString:@"_XCT_didBeginExecutingTestPlan"];
@@ -277,7 +277,7 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     self.recordVideoTask = nil;
 }
 
-#pragma mark - XCTMessagingChannel_IDEToRunner protocol
+#pragma mark - XCTMessagingChannel_RunnerToIDE protocol
 
 #pragma mark Process Launch Delegation
 
@@ -474,7 +474,7 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     return [NSString stringWithFormat:@"Received call for unhandled method (%@). Probably you should have a look at _IDETestManagerAPIMediator in IDEFoundation.framework and implement it. Good luck!", NSStringFromSelector(aSelector)];
 }
 
-// This will add more logs when unimplemented method from XCTMessagingChannel_IDEToRunner protocol is called
+// This will add more logs when unimplemented method from XCTMessagingChannel_RunnerToIDE protocol is called
 - (id)handleUnimplementedXCTRequest:(SEL)aSelector {
     NSAssert(nil, [self unknownMessageForSelector:_cmd]);
     return nil;

--- a/bp/src/BPTestBundleConnection.m
+++ b/bp/src/BPTestBundleConnection.m
@@ -192,34 +192,6 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return transport;
 }
 
-#pragma mark XCTMessagingChannel_IDEToRunner
-
-- (id)_XCT_didBeginExecutingTestPlan {
-    [BPUtils printInfo:INFO withString:@"_XCT_didBeginExecutingTestPlan"];
-    return nil;
-}
-
-- (id)_XCT_didFinishExecutingTestPlan {
-    [BPUtils printInfo:INFO withString:@"_XCT_didFinishExecutingTestPlan"];
-    return nil;
-}
-
-- (id)_XCT_testBundleReadyWithProtocolVersion:(NSNumber *)protocolVersion minimumVersion:(NSNumber *)minimumVersion {
-    self.connected = YES;
-    [BPUtils printInfo:INFO withString:@"Test bundle is connected.protocolVersion= %@, minimumVersion = %@", protocolVersion, minimumVersion];
-    return nil;
-}
-
-- (id)_XCT_didBeginInitializingForUITesting {
-    [BPUtils printInfo:INFO withString:@"Start initialization UI tests"];
-    return nil;
-}
-
-- (id)_XCT_initializationForUITestingDidFailWithError:(NSError *__strong)errPtr {
-    [BPUtils printInfo:INFO withString:@"_XCT_initializationForUITestingDidFailWithError is %@", errPtr];
-    return nil;
-}
-
 #pragma mark - Video Recording
 
 static inline NSString* getVideoPath(NSString *directory, NSString *testClass, NSString *method, NSInteger attemptNumber)
@@ -277,9 +249,23 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     self.recordVideoTask = nil;
 }
 
+// TODO: Xcode_12.5 ???
+- (id)_XCT_logMessage:(NSString *)message {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection log message: %@", message];
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_CrashReporting protocol
+// TODO: Xcode_12.5 XCTMessagingRole_CrashReporting belongs to XCTMessagingChannel_DaemonToIDE
+
+- (id)_XCT_handleCrashReportData:(NSData *)arg1 fromFileWithName:(NSString *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_handleCrashReportData : %@, from file with name: %@", arg1, arg2];
+    return nil;
+}
+
 #pragma mark - XCTMessagingChannel_RunnerToIDE protocol
 
-#pragma mark Process Launch Delegation
+#pragma mark - XCTMessagingRole_UIAutomation protocol
 
 - (id)_XCT_launchProcessWithPath:(NSString *)path bundleID:(NSString *)bundleID arguments:(NSArray *)arguments environmentVariables:(NSDictionary *)environment
 {
@@ -287,9 +273,9 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     [env addEntriesFromDictionary:[SimulatorHelper appLaunchEnvironmentWithBundleID:bundleID device:nil config:_context.config]];
     [env addEntriesFromDictionary:environment];
     NSDictionary *options = @{
-                              @"arguments": arguments,
-                              @"environment": env,
-                              };
+        @"arguments": arguments,
+        @"environment": env,
+    };
     NSError *error;
     DTXRemoteInvocationReceipt *receipt = [objc_lookUpClass("DTXRemoteInvocationReceipt") new];
     [BPUtils printInfo:DEBUGINFO withString:@"Installing UITargetApp: %@", path];
@@ -299,7 +285,7 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
         return nil;
     }
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection Launching app: %@ with options %@", bundleID, options];
-    
+
     self.appProcessPID = [self.simulator.device launchApplicationWithID:bundleID options:options error:&error];
     self.bundleID = bundleID;
     if (error) {
@@ -327,18 +313,57 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     return receipt;
 }
 
-#pragma mark iOS 10.x
-- (id)_XCT_handleCrashReportData:(NSData *)arg1 fromFileWithName:(NSString *)arg2 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_handleCrashReportData : %@, from file with name: %@", arg1, arg2];
+- (id)_XCT_didBeginInitializingForUITesting {
+    [BPUtils printInfo:INFO withString:@"Start initialization UI tests"];
     return nil;
 }
 
-#pragma mark Test Suite Progress
-
-- (id)_XCT_testSuite:(NSString *)tests didStartAt:(NSString *)time {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testSuite: %@, start %@", tests, time];
+- (id)_XCT_initializationForUITestingDidFailWithError:(NSError *__strong)errPtr {
+    [BPUtils printInfo:INFO withString:@"_XCT_initializationForUITestingDidFailWithError is %@", errPtr];
     return nil;
 }
+
+#pragma mark - XCTMessagingRole_TestReporting protocol
+
+- (id)_XCT_didBeginExecutingTestPlan {
+    [BPUtils printInfo:INFO withString:@"_XCT_didBeginExecutingTestPlan"];
+    return nil;
+}
+
+- (id)_XCT_didFinishExecutingTestPlan {
+    [BPUtils printInfo:INFO withString:@"_XCT_didFinishExecutingTestPlan"];
+    return nil;
+}
+
+- (id)_XCT_testBundleReadyWithProtocolVersion:(NSNumber *)protocolVersion minimumVersion:(NSNumber *)minimumVersion {
+    self.connected = YES;
+    [BPUtils printInfo:INFO withString:@"Test bundle is connected.protocolVersion= %@, minimumVersion = %@", protocolVersion, minimumVersion];
+    return nil;
+}
+
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)testSuite didStartAt:(NSString *)time {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testSuiteWithIdentifier: %@, start %@", testSuite, time];
+    return nil;
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)testCase didFinishWithStatus:(NSString *)statusString duration:(NSNumber *)duration {
+    [BPUtils printInfo:DEBUGINFO withString: @"BPTestBundleConnection_XCT_testCaseWithIdentifier: %@, didFinishWithStatus: %@, duration: %@", testCase, statusString, duration];
+    if ([self shouldRecordVideo]) {
+        [self stopVideoRecording:NO];
+    }
+    return nil;
+}
+
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 expectedFailureCount:(NSNumber *)arg6 uncaughtExceptionCount:(NSNumber *)arg7 testDuration:(NSNumber *)arg8 totalDuration:(NSNumber *)arg9 {
+    [BPUtils printInfo:DEBUGINFO withString: @"BPTestBundleConnection_XCT_testSuite: %@, didFinishAt: %@, runCount: %@, skipCount: %@, failureCount: %@, expectedFailureCount: %@, uncaughtExceptionCount: %@, testDuration: %@, totalDuration: %@", arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9];
+
+    if ([self shouldRecordVideo]) {
+        [self stopVideoRecording:YES];
+    }
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_TestReporting_Legacy protocol
 
 - (id)_XCT_testCaseDidStartForTestClass:(NSString *)testClass method:(NSString *)method {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testCaseDidStartForTestClass: %@ and method: %@", testClass, method];
@@ -353,17 +378,6 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     return nil;
 }
 
-// This looks like tested application logs
-- (id)_XCT_logDebugMessage:(NSString *)debugMessage {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection debug message: %@", debugMessage];
-    return nil;
-}
-
-- (id)_XCT_logMessage:(NSString *)message {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection log message: %@", message];
-    return nil;
-}
-
 - (id)_XCT_testCaseDidFinishForTestClass:(NSString *)testClass method:(NSString *)method withStatus:(NSString *)statusString duration:(NSNumber *)duration {
     [BPUtils printInfo:DEBUGINFO withString: @"BPTestBundleConnection_XCT_testCaseDidFinishForTestClass: %@, method: %@, withStatus: %@, duration: %@", testClass, method, statusString, duration];
     if ([self shouldRecordVideo]) {
@@ -372,19 +386,26 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     return nil;
 }
 
-- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)time runCount:(NSNumber *)count withFailures:(NSNumber *)failureCount unexpected:(NSNumber *)unexpectedCount testDuration:(NSNumber *)testDuration totalDuration:(NSNumber *)totalTime {
-    [BPUtils printInfo:DEBUGINFO withString: @"BPTestBundleConnection_XCT_testSuite: %@, didFinishAt: %@, runCount: %@, withFailures: %@, unexpectedCount: %@, testDuration: %@, totalDuration: %@", arg1, time, count, failureCount, unexpectedCount, testDuration, totalTime];
+#pragma mark - XCTMessagingRole_DebugLogging protocol
 
-    if ([self shouldRecordVideo]) {
-        [self stopVideoRecording:YES];
-    }
+// This looks like tested application logs
+- (id)_XCT_logDebugMessage:(NSString *)debugMessage {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection debug message: %@", debugMessage];
+    return nil;
+}
+#pragma mark - XCTMessagingRole_ActivityReporting protocol
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didFinishActivity:(XCActivityRecord *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testCaseWithIdentifier: %@, didFinishActivity: %@", arg1, arg2];
     return nil;
 }
 
-- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureMetric:(NSDictionary *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testMethod: %@, ofClass: %@, didMeasureMetric: %@, file: %@, line: %@", arg1, arg2, arg3, arg4, arg5];
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 willStartActivity:(XCActivityRecord *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testCaseWithIdentifier: %@, willStartActivity: %@", arg1, arg2];
     return nil;
 }
+
+#pragma mark - XCTMessagingRole_ActivityReporting_Legacy protocol
 
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 didFinishActivity:(XCActivityRecord *)arg3 {
     [BPUtils printInfo:DEBUGINFO withString: @"BPTestBundleConnection_XCT_testCase %@, method: %@, didFinishActivity: %@", arg1, arg2, arg3];
@@ -396,76 +417,87 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
     return nil;
 }
 
+#pragma mark - XCTMessagingRole_PerformanceMeasurementReporting protocol
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didMeasureMetric:(NSDictionary *)arg2 file:(NSString *)arg3 line:(NSNumber *)arg4 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testCaseWithIdentifier: %@, didMeasureMetric: %@, file: %@, line: %@", arg1, arg2, arg3, arg4];
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_PerformanceMeasurementReporting_Legacy protocol
+
+- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureMetric:(NSDictionary *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection_XCT_testMethod: %@, ofClass: %@, didMeasureMetric: %@, file: %@, line: %@", arg1, arg2, arg3, arg4, arg5];
+    return nil;
+}
+
 #pragma mark - Unimplemented
 
-- (id)_XCT_nativeFocusItemDidChangeAtTime:(NSNumber *)arg1 parameterSnapshot:(XCElementSnapshot *)arg2 applicationSnapshot:(XCElementSnapshot *)arg3 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection nativeFocusItemDidChangeAtATime"];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 timestamp:(NSNumber *)arg2 duration:(NSNumber *)arg3 startLocation:(NSDictionary *)arg4 startElementSnapshot:(XCElementSnapshot *)arg5 startApplicationSnapshot:(XCElementSnapshot *)arg6 endLocation:(NSDictionary *)arg7 endElementSnapshot:(XCElementSnapshot *)arg8 endApplicationSnapshot:(XCElementSnapshot *)arg9 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection recordedEventNames, ag1: %@", arg1];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedOrientationChange:(NSString *)arg1 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedOrientationChange: %@", arg1];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedFirstResponderChangedWithApplicationSnapshot:(XCElementSnapshot *)arg1 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedFirstResponderChanged"];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_exchangeCurrentProtocolVersion:(NSNumber *)arg1 minimumVersion:(NSNumber *)arg2 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: exhangeCurrentProtocolVersion: %@, minimumVersion: %@", arg1, arg2];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedKeyEventsWithApplicationSnapshot:(XCElementSnapshot *)arg1 characters:(NSString *)arg2 charactersIgnoringModifiers:(NSString *)arg3 modifierFlags:(NSNumber *)arg4 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedKeyEventsWithApplicationSnapshot"];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 duration:(NSNumber *)arg2 startLocation:(NSDictionary *)arg3 startElementSnapshot:(XCElementSnapshot *)arg4 startApplicationSnapshot:(XCElementSnapshot *)arg5 endLocation:(NSDictionary *)arg6 endElementSnapshot:(XCElementSnapshot *)arg7 endApplicationSnapshot:(XCElementSnapshot *)arg8 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedEventNames: %@", arg1];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedKeyEventsWithCharacters:(NSString *)arg1 charactersIgnoringModifiers:(NSString *)arg2 modifierFlags:(NSNumber *)arg3 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedKeyEventsWithCharacters: %@", arg1];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 duration:(NSNumber *)arg2 startElement:(XCAccessibilityElement *)arg3 startApplicationSnapshot:(XCElementSnapshot *)arg4 endElement:(XCAccessibilityElement *)arg5 endApplicationSnapshot:(XCElementSnapshot *)arg6 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedEventsName: %@, duration: %@", arg1, arg2];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEvent:(NSString *)arg1 targetElementID:(NSDictionary *)arg2 applicationSnapshot:(XCElementSnapshot *)arg3 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedEvent: %@, targetElementID: %@", arg1, arg2];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEvent:(NSString *)arg1 forElement:(NSString *)arg2 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: recordedEvent: %@, forElement: %@",arg1, arg2];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 didStallOnMainThreadInFile:(NSString *)arg3 line:(NSNumber *)arg4 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: testCase: %@, method: %@, didStallOnMainThreadInFile: %@, line: %@", arg1, arg2, arg3, arg4];
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 
-- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureValues:(NSArray *)arg3 forPerformanceMetricID:(NSString *)arg4 name:(NSString *)arg5 withUnits:(NSString *)arg6 baselineName:(NSString *)arg7 baselineAverage:(NSNumber *)arg8 maxPercentRegression:(NSNumber *)arg9 maxPercentRelativeStandardDeviation:(NSNumber *)arg10 file:(NSString *)arg11 line:(NSNumber *)arg12
-{
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: testMethod..."];
+- (id)_XCT_testCaseWasSkippedForTestClass:(NSString *)arg1 method:(NSString *)arg2 withMessage:(NSString *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 
-- (id)_XCT_testBundleReady {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestBundleConnection: testBundle Ready!"];
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 expectedFailureCount:(NSNumber *)arg6 uncaughtExceptionCount:(NSNumber *)arg7 testDuration:(NSNumber *)arg8 totalDuration:(NSNumber *)arg9 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 unexpectedFailureCount:(NSNumber *)arg6 testDuration:(NSNumber *)arg7 totalDuration:(NSNumber *)arg8 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 withFailures:(NSNumber *)arg4 unexpected:(NSNumber *)arg5 testDuration:(NSNumber *)arg6 totalDuration:(NSNumber *)arg7 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didStartAt:(NSString *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_didFailToBootstrapWithError:(NSError *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_reportTestWithIdentifier:(XCTTestIdentifier *)arg1 didExceedExecutionTimeAllowance:(NSNumber *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseDidStartWithIdentifier:(XCTTestIdentifier *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseDidStartWithIdentifier:(XCTTestIdentifier *)arg1 iteration:(NSNumber *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didRecordExpectedFailure:(XCTExpectedFailure *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didRecordIssue:(XCTIssue *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didStallOnMainThreadInFile:(NSString *)arg2 line:(NSNumber *)arg3 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 wasSkippedWithMessage:(NSString *)arg2 sourceCodeContext:(XCTSourceCodeContext *)arg3 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testRunnerReadyWithCapabilities:(XCTCapabilities *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)arg1 didRecordIssue:(XCTIssue *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_reportSelfDiagnosisIssue:(NSString *)arg1 description:(NSString *)arg2 {
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 

--- a/bp/src/BPTestDaemonConnection.h
+++ b/bp/src/BPTestDaemonConnection.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "PrivateHeaders/XCTest/XCTMessagingChannel_IDEToRunner-Protocol.h"
+#import "PrivateHeaders/XCTest/XCTMessagingChannel_RunnerToIDE-Protocol.h"
 
 // CoreSimulator
 #import "BPSimulator.h"

--- a/bp/src/BPTestDaemonConnection.m
+++ b/bp/src/BPTestDaemonConnection.m
@@ -113,9 +113,23 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return transport;
 }
 
+// TODO: Xcode_12.5 ???
+- (id)_XCT_logMessage:(NSString *)message {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_logMessage: %@", message];
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_CrashReporting protocol
+// TODO: Xcode_12.5 XCTMessagingRole_CrashReporting belongs to XCTMessagingChannel_DaemonToIDE
+
+- (id)_XCT_handleCrashReportData:(NSData *)arg1 fromFileWithName:(NSString *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_handleCrashReportData: %@, fromFileWithName: %@", arg1, arg2];
+    return nil;
+}
+
 #pragma mark - XCTMessagingChannel_RunnerToIDE protocol
 
-#pragma mark Process Launch Delegation
+#pragma mark - XCTMessagingRole_UIAutomation protocol
 
 - (id)_XCT_launchProcessWithPath:(NSString *)path bundleID:(NSString *)bundleID arguments:(NSArray *)arguments environmentVariables:(NSDictionary *)environment {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_launchProcessWithPath: %@, bundleID: %@, arguments: %@, environmentVariables: %@", path, bundleID, arguments, environment];
@@ -132,22 +146,6 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 
-- (id)_XCT_didBeginExecutingTestPlan {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_didBeginExecutingTestPlan"];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_didFinishExecutingTestPlan {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_didFinishExecutingTestPlan"];
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-#pragma mark iOS 10.x
-- (id)_XCT_handleCrashReportData:(NSData *)arg1 fromFileWithName:(NSString *)arg2 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_handleCrashReportData: %@, fromFileWithName: %@", arg1, arg2];
-    return nil;
-}
-
 - (id)_XCT_didBeginInitializingForUITesting {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_didBeginInitializingForUITesting"];
     return nil;
@@ -158,17 +156,39 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return nil;
 }
 
+#pragma mark - XCTMessagingRole_TestReporting protocol
+
+- (id)_XCT_didBeginExecutingTestPlan {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_didBeginExecutingTestPlan"];
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_didFinishExecutingTestPlan {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_didFinishExecutingTestPlan"];
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
 - (id)_XCT_testBundleReadyWithProtocolVersion:(NSNumber *)protocolVersion minimumVersion:(NSNumber *)minimumVersion {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testBundleReadyWithProtocolVersion : %@, minimumVersion: %@", protocolVersion, minimumVersion];
     return nil;
 }
 
-#pragma mark Test Suite Progress
-
-- (id)_XCT_testSuite:(NSString *)tests didStartAt:(NSString *)time {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testSuite : %@, didStartAt: %@", tests, time];
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)testSuite didStartAt:(NSString *)time {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testSuiteWithIdentifier : %@, didStartAt: %@", testSuite, time];
     return [self handleUnimplementedXCTRequest:_cmd];
 }
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)testCase didFinishWithStatus:(NSString *)statusString duration:(NSNumber *)duration {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCaseWithIdentifier: %@, didFinishWithStatus: %@, duration: %@", testCase, statusString, duration];
+    return nil;
+}
+
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 expectedFailureCount:(NSNumber *)arg6 uncaughtExceptionCount:(NSNumber *)arg7 testDuration:(NSNumber *)arg8 totalDuration:(NSNumber *)arg9 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testSuite: %@, didFinishAt: %@, runCount: %@, skipCount: %@, failureCount: %@, expectedFailureCount: %@, uncaughtExceptionCount: %@, testDuration: %@, totalDuration: %@", arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9];
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_TestReporting_Legacy protocol
 
 - (id)_XCT_testCaseDidStartForTestClass:(NSString *)testClass method:(NSString *)method {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCaseDidStartForTestClass : %@, method: %@", testClass, method];
@@ -180,25 +200,31 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return nil;
 }
 
-- (id)_XCT_logDebugMessage:(NSString *)debugMessage {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_logDebugMessage: %@", debugMessage];
-    return nil;
-}
-
-- (id)_XCT_logMessage:(NSString *)message {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_logMessage: %@", message];
-    return nil;
-}
-
 - (id)_XCT_testCaseDidFinishForTestClass:(NSString *)testClass method:(NSString *)method withStatus:(NSString *)statusString duration:(NSNumber *)duration {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCaseDidFinishForTestClass: %@, method: %@, withStatus: %@, duration: %@", testClass, method, statusString, duration];
     return nil;
 }
 
-- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 withFailures:(NSNumber *)arg4 unexpected:(NSNumber *)arg5 testDuration:(NSNumber *)arg6 totalDuration:(NSNumber *)arg7 {
-    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testSuite: %@, didFinishAt: %@, runCount: %@, withFailures: %@, unexpected: %@, testDuration: %@, totalDuration: %@", arg1, arg2, arg3, arg4, arg5, arg6, arg7];
+#pragma mark - XCTMessagingRole_DebugLogging protocol
+
+- (id)_XCT_logDebugMessage:(NSString *)debugMessage {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_logDebugMessage: %@", debugMessage];
     return nil;
 }
+
+#pragma mark - XCTMessagingRole_ActivityReporting protocol
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didFinishActivity:(XCActivityRecord *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCaseWithIdentifier: %@, didFinishActivity: %@", arg1, arg2];
+    return nil;
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 willStartActivity:(XCActivityRecord *)arg2 {
+    [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCaseWithIdentifier: %@, willStartActivity: %@", arg1, arg2];
+    return nil;
+}
+
+#pragma mark - XCTMessagingRole_ActivityReporting_Legacy protocol
 
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 didFinishActivity:(XCActivityRecord *)arg3 {
     [BPUtils printInfo:DEBUGINFO withString:@"BPTestDaemonConnection_XCT_testCase: %@, method: %@, didFinishActivity: %@", arg1, arg2, arg3];
@@ -212,63 +238,79 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
 #pragma mark - Unimplemented
 
-- (id)_XCT_nativeFocusItemDidChangeAtTime:(NSNumber *)arg1 parameterSnapshot:(XCElementSnapshot *)arg2 applicationSnapshot:(XCElementSnapshot *)arg3 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 timestamp:(NSNumber *)arg2 duration:(NSNumber *)arg3 startLocation:(NSDictionary *)arg4 startElementSnapshot:(XCElementSnapshot *)arg5 startApplicationSnapshot:(XCElementSnapshot *)arg6 endLocation:(NSDictionary *)arg7 endElementSnapshot:(XCElementSnapshot *)arg8 endApplicationSnapshot:(XCElementSnapshot *)arg9 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedOrientationChange:(NSString *)arg1 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedFirstResponderChangedWithApplicationSnapshot:(XCElementSnapshot *)arg1 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_exchangeCurrentProtocolVersion:(NSNumber *)arg1 minimumVersion:(NSNumber *)arg2 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedKeyEventsWithApplicationSnapshot:(XCElementSnapshot *)arg1 characters:(NSString *)arg2 charactersIgnoringModifiers:(NSString *)arg3 modifierFlags:(NSNumber *)arg4 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 duration:(NSNumber *)arg2 startLocation:(NSDictionary *)arg3 startElementSnapshot:(XCElementSnapshot *)arg4 startApplicationSnapshot:(XCElementSnapshot *)arg5 endLocation:(NSDictionary *)arg6 endElementSnapshot:(XCElementSnapshot *)arg7 endApplicationSnapshot:(XCElementSnapshot *)arg8 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedKeyEventsWithCharacters:(NSString *)arg1 charactersIgnoringModifiers:(NSString *)arg2 modifierFlags:(NSNumber *)arg3 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEventNames:(NSArray *)arg1 duration:(NSNumber *)arg2 startElement:(XCAccessibilityElement *)arg3 startApplicationSnapshot:(XCElementSnapshot *)arg4 endElement:(XCAccessibilityElement *)arg5 endApplicationSnapshot:(XCElementSnapshot *)arg6 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEvent:(NSString *)arg1 targetElementID:(NSDictionary *)arg2 applicationSnapshot:(XCElementSnapshot *)arg3 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_recordedEvent:(NSString *)arg1 forElement:(NSString *)arg2 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
-- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureMetric:(NSDictionary *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
-    return [self handleUnimplementedXCTRequest:_cmd];
-}
-
 - (id)_XCT_testCase:(NSString *)arg1 method:(NSString *)arg2 didStallOnMainThreadInFile:(NSString *)arg3 line:(NSNumber *)arg4 {
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 
-- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureValues:(NSArray *)arg3 forPerformanceMetricID:(NSString *)arg4 name:(NSString *)arg5 withUnits:(NSString *)arg6 baselineName:(NSString *)arg7 baselineAverage:(NSNumber *)arg8 maxPercentRegression:(NSNumber *)arg9 maxPercentRelativeStandardDeviation:(NSNumber *)arg10 file:(NSString *)arg11 line:(NSNumber *)arg12 {
+- (id)_XCT_testCaseWasSkippedForTestClass:(NSString *)arg1 method:(NSString *)arg2 withMessage:(NSString *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 
-- (id)_XCT_testBundleReady {
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 expectedFailureCount:(NSNumber *)arg6 uncaughtExceptionCount:(NSNumber *)arg7 testDuration:(NSNumber *)arg8 totalDuration:(NSNumber *)arg9 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 skipCount:(NSNumber *)arg4 failureCount:(NSNumber *)arg5 unexpectedFailureCount:(NSNumber *)arg6 testDuration:(NSNumber *)arg7 totalDuration:(NSNumber *)arg8 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didFinishAt:(NSString *)arg2 runCount:(NSNumber *)arg3 withFailures:(NSNumber *)arg4 unexpected:(NSNumber *)arg5 testDuration:(NSNumber *)arg6 totalDuration:(NSNumber *)arg7 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuite:(NSString *)arg1 didStartAt:(NSString *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_didFailToBootstrapWithError:(NSError *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_reportTestWithIdentifier:(XCTTestIdentifier *)arg1 didExceedExecutionTimeAllowance:(NSNumber *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseDidStartWithIdentifier:(XCTTestIdentifier *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseDidStartWithIdentifier:(XCTTestIdentifier *)arg1 iteration:(NSNumber *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didRecordExpectedFailure:(XCTExpectedFailure *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didRecordIssue:(XCTIssue *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didStallOnMainThreadInFile:(NSString *)arg2 line:(NSNumber *)arg3 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 wasSkippedWithMessage:(NSString *)arg2 sourceCodeContext:(XCTSourceCodeContext *)arg3 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testRunnerReadyWithCapabilities:(XCTCapabilities *)arg1 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testSuiteWithIdentifier:(XCTTestIdentifier *)arg1 didRecordIssue:(XCTIssue *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_reportSelfDiagnosisIssue:(NSString *)arg1 description:(NSString *)arg2 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testCaseWithIdentifier:(XCTTestIdentifier *)arg1 didMeasureMetric:(NSDictionary *)arg2 file:(NSString *)arg3 line:(NSNumber *)arg4 {
+    return [self handleUnimplementedXCTRequest:_cmd];
+}
+
+- (id)_XCT_testMethod:(NSString *)arg1 ofClass:(NSString *)arg2 didMeasureMetric:(NSDictionary *)arg3 file:(NSString *)arg4 line:(NSNumber *)arg5 {
     return [self handleUnimplementedXCTRequest:_cmd];
 }
 

--- a/bp/src/BPTestDaemonConnection.m
+++ b/bp/src/BPTestDaemonConnection.m
@@ -38,7 +38,7 @@
 
 static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
-@interface BPTestDaemonConnection()<XCTMessagingChannel_IDEToRunner>
+@interface BPTestDaemonConnection()<XCTMessagingChannel_DaemonToIDE>
 @property (nonatomic, assign) BOOL connected;
 @end
 
@@ -113,7 +113,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return transport;
 }
 
-#pragma mark - XCTMessagingChannel_IDEToRunner protocol
+#pragma mark - XCTMessagingChannel_RunnerToIDE protocol
 
 #pragma mark Process Launch Delegation
 
@@ -277,7 +277,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     return [NSString stringWithFormat:@"Received call for unhandled method (%@). Probably you should have a look at _IDETestManagerAPIMediator in IDEFoundation.framework and implement it. Good luck!", NSStringFromSelector(aSelector)];
 }
 
-// This will add more logs when unimplemented method from XCTMessagingChannel_IDEToRunner protocol is called
+// This will add more logs when unimplemented method from XCTMessagingChannel_RunnerToIDE protocol is called
 - (id)handleUnimplementedXCTRequest:(SEL)aSelector {
     [BPUtils printInfo:DEBUGINFO withString:@"TMD: unimplemented: %s", sel_getName(aSelector)];
     NSAssert(nil, [self unknownMessageForSelector:_cmd]);

--- a/bp/src/NSString+IdentifierString.h
+++ b/bp/src/NSString+IdentifierString.h
@@ -1,0 +1,16 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (IdentifierString)
+
+- (NSString *)identifierString;
+
+@end

--- a/bp/src/NSString+IdentifierString.m
+++ b/bp/src/NSString+IdentifierString.m
@@ -1,0 +1,18 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+
+#import "NSString+IdentifierString.h"
+
+@implementation NSString (IdentifierString)
+
+- (NSString *)identifierString {
+    return self;
+}
+
+@end


### PR DESCRIPTION
Changes:
1) Correct protocol mapping
XCTestManager_IDEInterface -> XCTMessagingChannel_RunnerToIDE
XCTestDriverInterface -> XCTMessagingChannel_IDEToRunner
XCTestManager_DaemonConnectionInterface -> XCTMessagingChannel_IDEToDaemon

2) Add the references to the headers

3) Add the implementation of the protocol functions