### PR TITLE
Small cleanups pre 12.5

### DIFF
--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -13,8 +13,6 @@
 #import "BPConstants.h"
 #import "BPCreateSimulatorHandler.h"
 #import "BPSimulator.h"
-#import "BPTestBundleConnection.h"
-#import "BPTestDaemonConnection.h"
 #import "BPTreeParser.h"
 #import "BPUtils.h"
 #import "BPWaitTimer.h"

--- a/bp/src/BPTestBundleConnection.h
+++ b/bp/src/BPTestBundleConnection.h
@@ -16,7 +16,6 @@
 @end
 
 @interface BPTestBundleConnection : NSObject
-@property (nonatomic, strong) BPConfiguration *config;
 @property (nonatomic, strong) BPExecutionContext *context;
 @property (nonatomic, strong) BPSimulator *simulator;
 @property (nonatomic, copy) void (^completionBlock)(NSError *, pid_t);

--- a/bp/src/BPTestBundleConnection.m
+++ b/bp/src/BPTestBundleConnection.m
@@ -114,7 +114,7 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
                 path = NSBundle.mainBundle.executablePath;
             }
             __block DTXRemoteInvocationReceipt *receipt = [remoteProxy
-                                                           _IDE_initiateSessionWithIdentifier:self.config.sessionIdentifier
+                                                           _IDE_initiateSessionWithIdentifier:self.context.config.sessionIdentifier
                                                            forClient:[self clientProcessUniqueIdentifier]
                                                            atPath:path
                                                            protocolVersion:@(BP_DAEMON_PROTOCOL_VERSION)];
@@ -282,7 +282,7 @@ static inline NSString* getVideoPath(NSString *directory, NSString *testClass, N
 - (id)_XCT_launchProcessWithPath:(NSString *)path bundleID:(NSString *)bundleID arguments:(NSArray *)arguments environmentVariables:(NSDictionary *)environment
 {
     NSMutableDictionary<NSString *, NSString *> *env = [[NSMutableDictionary alloc] init];
-    [env addEntriesFromDictionary:[SimulatorHelper appLaunchEnvironmentWithBundleID:bundleID device:nil config:_config]];
+    [env addEntriesFromDictionary:[SimulatorHelper appLaunchEnvironmentWithBundleID:bundleID device:nil config:_context.config]];
     [env addEntriesFromDictionary:environment];
     NSDictionary *options = @{
                               @"arguments": arguments,

--- a/bp/src/BPTestDaemonConnection.h
+++ b/bp/src/BPTestDaemonConnection.h
@@ -15,6 +15,6 @@
 @interface BPTestDaemonConnection : NSObject
 @property (nonatomic, assign) pid_t testRunnerPid;
 @property (nonatomic, strong) BPSimulator *simulator;
-- (instancetype)initWithDevice:(BPSimulator *)device andInterface:(id<XCTestManager_IDEInterface>)interface;
+- (instancetype)initWithDevice:(BPSimulator *)device andInterface:(id<XCTestManager_IDEInterface>)interface andTestRunnerPID: (pid_t) pid;
 - (void)connectWithTimeout:(NSTimeInterval)timeout;
 @end

--- a/bp/src/BPTestDaemonConnection.m
+++ b/bp/src/BPTestDaemonConnection.m
@@ -43,18 +43,19 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
 
 @implementation BPTestDaemonConnection
 
-- (instancetype)initWithDevice:(BPSimulator *)simulator andInterface:(id<XCTestManager_IDEInterface>)interface {
+- (instancetype)initWithDevice:(BPSimulator *)simulator andInterface:(id<XCTestManager_IDEInterface>)interface andTestRunnerPID: (pid_t) pid {
     self = [super init];
     if (self) {
         self.simulator = simulator;
         self.interface = interface;
+        self.testRunnerPid = pid;
     }
     return self;
 }
 
 - (void)connectWithTimeout:(NSTimeInterval)timeout {
     [self connect];
-    // Pool connection status till it passes.
+    // Poll connection status till it passes.
     [BPUtils runWithTimeOut:timeout until:^BOOL{
         return self.connected;
     }];

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -433,11 +433,8 @@ static void onInterrupt(int ignore) {
         return;
     }
     BPTestBundleConnection *bConnection = [[BPTestBundleConnection alloc] initWithContext:context andInterface:self];
-    bConnection.simulator = context.runner;
-    bConnection.config = self.config;
+    BPTestDaemonConnection *dConnection = [[BPTestDaemonConnection alloc] initWithDevice:context.runner andInterface:nil andTestRunnerPID: context.pid];
 
-    BPTestDaemonConnection *dConnection = [[BPTestDaemonConnection alloc] initWithDevice:context.runner andInterface:nil];
-    dConnection.testRunnerPid = context.pid;
     [dConnection connectWithTimeout:180];
     [bConnection connectWithTimeout:180];
     [bConnection startTestPlan];


### PR DESCRIPTION
This is a small clean-up so that #491 is smaller.

It just removes some unnecessary imports, and replaces a call to `popen()` with `NSTask`