### PR TITLE
Bugfix: Pack tests by test count if test estimates are missing or adding up to be zero

### DIFF
--- a/BPSampleApp/BPSampleApp.xcodeproj/project.pbxproj
+++ b/BPSampleApp/BPSampleApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		BAB24F5D1DB5D83C00867756 /* BPAppNegativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BAB24F5C1DB5D83C00867756 /* BPAppNegativeTests.m */; };
 		BAFCCA601E36DC2000E33C31 /* BPSampleAppUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = BAFCCA5F1E36DC2000E33C31 /* BPSampleAppUITests.m */; };
 		E492360122EF61F300395D98 /* BPSampleAppMoarTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E492360022EF61F300395D98 /* BPSampleAppMoarTests.m */; };
+		E4F8A34326F3B1AD00FE1267 /* BPSampleAppNewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E4F8A33B26F3B12F00FE1267 /* BPSampleAppNewTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,13 @@
 			remoteGlobalIDString = BAB24F2D1DB5D45E00867756;
 			remoteInfo = BPSampleApp;
 		};
+		E4F8A33F26F3B1AD00FE1267 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BAB24F261DB5D45E00867756 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BAB24F2D1DB5D45E00867756;
+			remoteInfo = BPSampleApp;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +113,8 @@
 		BAFCCA5F1E36DC2000E33C31 /* BPSampleAppUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPSampleAppUITests.m; sourceTree = "<group>"; };
 		BAFCCA611E36DC2000E33C31 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E492360022EF61F300395D98 /* BPSampleAppMoarTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPSampleAppMoarTests.m; sourceTree = "<group>"; };
+		E4F8A33B26F3B12F00FE1267 /* BPSampleAppNewTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPSampleAppNewTests.m; sourceTree = "<group>"; };
+		E4F8A34A26F3B1AD00FE1267 /* BPSampleAppNewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BPSampleAppNewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +161,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BAFCCA5A1E36DC2000E33C31 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4F8A34526F3B1AD00FE1267 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -213,6 +230,7 @@
 				BA4BCFC61DC47EC700592FA4 /* BPSampleAppHangingTests.xctest */,
 				BA9C2DD21DD7F182007CB967 /* BPSampleAppFatalErrorTests.xctest */,
 				BAFCCA5D1E36DC2000E33C31 /* BPSampleAppUITests.xctest */,
+				E4F8A34A26F3B1AD00FE1267 /* BPSampleAppNewTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -250,6 +268,7 @@
 				BAB24F4D1DB5D45E00867756 /* Info.plist */,
 				32FEEBBC2012B93D005916EF /* BPSampleAppSwiftTests.swift */,
 				32FEEBBB2012B93D005916EF /* BPSampleAppTests-Bridging-Header.h */,
+				E4F8A33B26F3B12F00FE1267 /* BPSampleAppNewTests.m */,
 			);
 			path = BPSampleAppTests;
 			sourceTree = "<group>";
@@ -400,6 +419,24 @@
 			productReference = BAFCCA5D1E36DC2000E33C31 /* BPSampleAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		E4F8A33D26F3B1AD00FE1267 /* BPSampleAppNewTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4F8A34726F3B1AD00FE1267 /* Build configuration list for PBXNativeTarget "BPSampleAppNewTests" */;
+			buildPhases = (
+				E4F8A34026F3B1AD00FE1267 /* Sources */,
+				E4F8A34526F3B1AD00FE1267 /* Frameworks */,
+				E4F8A34626F3B1AD00FE1267 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E4F8A33E26F3B1AD00FE1267 /* PBXTargetDependency */,
+			);
+			name = BPSampleAppNewTests;
+			productName = BPSampleAppTests;
+			productReference = E4F8A34A26F3B1AD00FE1267 /* BPSampleAppNewTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -451,6 +488,9 @@
 						ProvisioningStyle = Automatic;
 						TestTargetID = BAB24F2D1DB5D45E00867756;
 					};
+					E4F8A33D26F3B1AD00FE1267 = {
+						DevelopmentTeam = 57Y47U492U;
+					};
 				};
 			};
 			buildConfigurationList = BAB24F291DB5D45E00867756 /* Build configuration list for PBXProject "BPSampleApp" */;
@@ -473,6 +513,7 @@
 				BA4BCFC51DC47EC700592FA4 /* BPSampleAppHangingTests */,
 				BA9C2DD11DD7F182007CB967 /* BPSampleAppFatalErrorTests */,
 				BAFCCA5C1E36DC2000E33C31 /* BPSampleAppUITests */,
+				E4F8A33D26F3B1AD00FE1267 /* BPSampleAppNewTests */,
 			);
 		};
 /* End PBXProject section */
@@ -525,6 +566,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BAFCCA5B1E36DC2000E33C31 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4F8A34626F3B1AD00FE1267 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -595,6 +643,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E4F8A34026F3B1AD00FE1267 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4F8A34326F3B1AD00FE1267 /* BPSampleAppNewTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -627,6 +683,11 @@
 			isa = PBXTargetDependency;
 			target = BAB24F2D1DB5D45E00867756 /* BPSampleApp */;
 			targetProxy = BAFCCA621E36DC2000E33C31 /* PBXContainerItemProxy */;
+		};
+		E4F8A33E26F3B1AD00FE1267 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BAB24F2D1DB5D45E00867756 /* BPSampleApp */;
+			targetProxy = E4F8A33F26F3B1AD00FE1267 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -961,6 +1022,41 @@
 			};
 			name = Release;
 		};
+		E4F8A34826F3B1AD00FE1267 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = 57Y47U492U;
+				INFOPLIST_FILE = BPSampleAppTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = LI.BPSampleAppNewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BPSampleAppTests/BPSampleAppTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BPSampleApp.app/BPSampleApp";
+			};
+			name = Debug;
+		};
+		E4F8A34926F3B1AD00FE1267 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = 57Y47U492U;
+				INFOPLIST_FILE = BPSampleAppTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = LI.BPSampleAppNewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BPSampleAppTests/BPSampleAppTests-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BPSampleApp.app/BPSampleApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1035,6 +1131,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
+		};
+		E4F8A34726F3B1AD00FE1267 /* Build configuration list for PBXNativeTarget "BPSampleAppNewTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4F8A34826F3B1AD00FE1267 /* Debug */,
+				E4F8A34926F3B1AD00FE1267 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
+++ b/BPSampleApp/BPSampleApp.xcodeproj/xcshareddata/xcschemes/BPSampleApp.xcscheme
@@ -207,6 +207,16 @@
                ReferencedContainer = "container:BPSampleApp.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4F8A33D26F3B1AD00FE1267"
+               BuildableName = "BPSampleAppNewTests.xctest"
+               BlueprintName = "BPSampleAppNewTests"
+               ReferencedContainer = "container:BPSampleApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/BPSampleApp/BPSampleAppTests/BPSampleAppNewTests.m
+++ b/BPSampleApp/BPSampleAppTests/BPSampleAppNewTests.m
@@ -1,0 +1,35 @@
+//
+//  BPSampleAppNewTests.m
+//  BPSampleAppTests
+//
+//  Created by Ravi K. Mandala on 9/16/21.
+//  Copyright © 2021 LinkedIn. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface BPSampleAppNewTests : XCTestCase
+
+@end
+
+
+@implementation BPSampleAppNewTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testCase1000 { XCTAssert(YES);}
+- (void)testCase1001 { XCTAssert(YES);}
+- (void)testCase1002 { XCTAssert(YES);}
+- (void)testCase1003 { XCTAssert(YES);}
+- (void)testCase1004 { XCTAssert(YES);}
+
+@end

--- a/bp/bp.xcodeproj/project.pbxproj
+++ b/bp/bp.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		7A564C0D1DA817DE001BCEC2 /* BPReporters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A564C081DA817DE001BCEC2 /* BPReporters.m */; };
 		7A564C0E1DA817DE001BCEC2 /* BPTreeObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A564C0A1DA817DE001BCEC2 /* BPTreeObjects.m */; };
 		7A564C0F1DA817DE001BCEC2 /* BPTreeParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A564C0C1DA817DE001BCEC2 /* BPTreeParser.m */; };
-		7A58D0751D622BF0002F6B6D /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A58D0741D622BF0002F6B6D /* DVTiPhoneSimulatorRemoteClient.framework */; };
 		7A7901861D5CB679004D4325 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7901851D5CB679004D4325 /* main.m */; };
 		7A7E7BC01DF22CE1007928F3 /* BPExecutionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7E7BBF1DF22CE1007928F3 /* BPExecutionContext.m */; };
 		7A7E7BC11DF22CE1007928F3 /* BPExecutionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7E7BBF1DF22CE1007928F3 /* BPExecutionContext.m */; };
@@ -155,7 +154,6 @@
 		7A564C0A1DA817DE001BCEC2 /* BPTreeObjects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPTreeObjects.m; sourceTree = "<group>"; };
 		7A564C0B1DA817DE001BCEC2 /* BPTreeParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPTreeParser.h; sourceTree = "<group>"; };
 		7A564C0C1DA817DE001BCEC2 /* BPTreeParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPTreeParser.m; sourceTree = "<group>"; };
-		7A58D0741D622BF0002F6B6D /* DVTiPhoneSimulatorRemoteClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTiPhoneSimulatorRemoteClient.framework; path = ../SharedFrameworks/DVTiPhoneSimulatorRemoteClient.framework; sourceTree = DEVELOPER_DIR; };
 		7A58D2E51D62689B002F6B6D /* DVTFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTFoundation.framework; path = ../SharedFrameworks/DVTFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		7A7901821D5CB679004D4325 /* bp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = bp; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A7901851D5CB679004D4325 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -327,7 +325,6 @@
 				B324B91D1F280AD100AAE2BC /* CoreSimulator.framework in Frameworks */,
 				7AB913001D5E209800621608 /* AppKit.framework in Frameworks */,
 				7AB913011D5E209800621608 /* Foundation.framework in Frameworks */,
-				7A58D0751D622BF0002F6B6D /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -446,7 +443,6 @@
 				7AB912FE1D5E209800621608 /* AppKit.framework */,
 				7A79018E1D5D136F004D4325 /* CoreSimulator.framework */,
 				7A58D2E51D62689B002F6B6D /* DVTFoundation.framework */,
-				7A58D0741D622BF0002F6B6D /* DVTiPhoneSimulatorRemoteClient.framework */,
 				7AB912FF1D5E209800621608 /* Foundation.framework */,
 			);
 			name = Frameworks;
@@ -1041,8 +1037,6 @@
 					"-weak_framework",
 					DVTFoundation,
 					"-weak_framework",
-					DVTiPhoneSimulatorRemoteClient,
-					"-weak_framework",
 					CoreSimulator,
 					"-weak_framework",
 					XCTest,
@@ -1083,8 +1077,6 @@
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					DVTFoundation,
-					"-weak_framework",
-					DVTiPhoneSimulatorRemoteClient,
 					"-weak_framework",
 					CoreSimulator,
 					"-weak_framework",

--- a/bp/tests/BPTestHelper.h
+++ b/bp/tests/BPTestHelper.h
@@ -17,6 +17,9 @@
 // Return the path to the test plan json file. The json is packed into the app bundle as resource
 + (NSString *)testPlanPath;
 
+// Return the path to the sample app's xctest with new test cases
++ (NSString *)sampleAppNewTestsBundlePath;
+
 // Return the path to the sample app's xctest with 1000 test cases
 + (NSString *)sampleAppBalancingTestsBundlePath;
 

--- a/bp/tests/BPTestHelper.m
+++ b/bp/tests/BPTestHelper.m
@@ -20,6 +20,11 @@
     return [[self sampleAppPath] stringByAppendingPathComponent:@"test_plan.json"];
 }
 
+// Return the path to the sample app's xctest with new test cases
++ (NSString *)sampleAppNewTestsBundlePath {
+    return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppNewTests.xctest"];
+}
+
 // Return the path to the sample app's xctest with 1000 test cases
 + (NSString *)sampleAppBalancingTestsBundlePath {
     return [[self sampleAppPath] stringByAppendingString:@"/PlugIns/BPSampleAppTests.xctest"];


### PR DESCRIPTION
Fixing https://github.com/MobileNativeFoundation/bluepill/issues/511 by choosing to pack tests by test count if and when test estimates are missing or adding up to be zero.

\cc @ob @chenxiao0228 