### PR TITLE
Fix how the test host app is made into a .app

### DIFF
--- a/bptestrunner/bluepill_batch_test.bzl
+++ b/bptestrunner/bluepill_batch_test.bzl
@@ -29,9 +29,9 @@ def _bluepill_batch_test_impl(ctx):
 
         #test_plan
         test_plan = struct(
-            test_host = test_host.basename.rstrip(
+            test_host = test_host.basename.split(
                 "." + test_host.extension,
-            ) + ".app",
+            )[0] + ".app",
             environment = test_env,
             arguments = test_env,
             test_bundle_path = bundle_info.bundle_name + bundle_info.bundle_extension,


### PR DESCRIPTION
In the previous was we would `rstrip` the test_host's app extension. If this happened to be the same as the end of the app name it would strip that too.
For example if it was `Foo-App.app` it would change to `Foo-A.app`.

This updates to take whatever is before the app extension by splitting the test_host's extension + '.' and taking the first entry.

This fixes https://github.com/MobileNativeFoundation/bluepill/issues/528