### PR TITLE
Specify platform to exclude tvOS, watchOS

### DIFF
--- a/Bluepill.podspec
+++ b/Bluepill.podspec
@@ -1,6 +1,8 @@
 Pod::Spec.new do |s|
     s.name           = 'Bluepill'
     s.version        = `echo $(git describe --always --tags | cut -c 2-)`
+    s.ios.deployment_target = '13.0'
+    s.osx.deployment_target = '12.0'
     s.summary        = 'A tool to run iOS tests in parallel using multiple simulators.'
     s.homepage       = 'https://github.com/linkedin/bluepill'
     s.license        = { type: 'BSD', file: 'LICENSE' }


### PR DESCRIPTION
tvOS and watchOS sdks and their simulators are not installed by default
  with Xcode 14. So specifying osx and ios to workaround them.
This podspec is mean to bring in the binaries to Pods folder so other tools
  are able to use it. It does not build or mean to be consumed as a library