### PR TITLE
Expand $TEST_UNDECLARED_OUTPUTS_DIR  when running test from bazel

### DIFF
--- a/bptestrunner/bluepill_batch_test_runner.template.sh
+++ b/bptestrunner/bluepill_batch_test_runner.template.sh
@@ -64,8 +64,9 @@ if [ -f "$BP_TEST_ESTIMATE_JSON" ]; then
     TIME_ESTIMATE_ARG="--test-time-estimates-json $(basename "$BP_TEST_ESTIMATE_JSON")"
 fi
 
-# Copy rule-generated test plan file to working folder
-cp "$BP_TEST_PLAN" $BP_WORKING_FOLDER
+# Expand $TEST_UNDECLARED_OUTPUTS_DIR in rule-generated test plan file
+# And copy it to working folder
+sed 's/$TEST_UNDECLARED_OUTPUTS_DIR/'"${TEST_UNDECLARED_OUTPUTS_DIR//\//\\/}"'/g' $BP_TEST_PLAN > $BP_WORKING_FOLDER/$BP_TEST_PLAN
 BP_TEST_PLAN_ARG="$(basename "$BP_TEST_PLAN")"
 
 # Copy bluepill and bp executables to working folder


### PR DESCRIPTION
Currently when running bluepill from bazel, `$TEST_UNDECLARED_OUTPUTS_DIR` is not accessible from test runtime by passing with `--test_env`

Supporting it by expanding the variable in the shell script and passing it to the test plan. 

So we can run something like `bazel test Taget --config Debug --test_env SCREENSHOT_DIR=\$TEST_UNDECLARED_OUTPUTS_DIR/screenshots`. Then the screenshot can be saved to the undeclared outputs dir and be packaged to the final `bazel-testlog` folder

ref: https://bazel.build/reference/test-encyclopedia#initial-conditions