### PR TITLE
Proper shutdown mechanism

### DIFF
--- a/bp/src/BPSimulator.h
+++ b/bp/src/BPSimulator.h
@@ -72,5 +72,4 @@
 - (BOOL)needsRetry;
 - (BPExitStatus)exitStatus;
 - (BOOL)isApplicationLaunched;
-- (BOOL)shutdownSimulatorWithError:(id *)error;
 @end

--- a/bp/src/BPSimulator.h
+++ b/bp/src/BPSimulator.h
@@ -72,4 +72,5 @@
 - (BOOL)needsRetry;
 - (BPExitStatus)exitStatus;
 - (BOOL)isApplicationLaunched;
+- (BOOL)shutdownSimulatorWithError:(id *)error;
 @end

--- a/bp/src/BPSimulator.m
+++ b/bp/src/BPSimulator.m
@@ -127,7 +127,8 @@
         }];
         return nil;
     } else {
-        [simDevice shutdownWithError:errPtr];
+//        [simDevice shutdownWithError:errPtr];
+        [self shutdownSimulatorWithError:errPtr];
         if(*errPtr) {
             [BPUtils printInfo:ERROR withString:@"Shutdown simulator failed with error: %@", [*errPtr localizedDescription]];
             [deviceSet deleteDeviceAsync:simDevice completionHandler:^(NSError *error) {
@@ -307,6 +308,69 @@
     return YES;
 }
 
+- (void)eraseSimulator:(SimDevice *)device withError:(id *) error{
+    NSLog(@"Erasing Simulator %@", device.UDID.UUIDString);
+    [device eraseContentsAndSettingsWithError:error];
+    if (*error) {
+        NSLog(@"Error erasing simulator: %@", *error);
+    } else {
+        NSLog(@"Simulator erased successfully.");
+    }
+}
+
+- (BOOL)waitForSimulatorShutdown:(SimDevice *)device {
+    NSDate *startTime = [NSDate date];
+    NSTimeInterval timeoutInterval = 30.0;
+
+    while (![device.stateString isEqualToString:@"Shutdown"]) {
+        NSTimeInterval elapsedTime = -[startTime timeIntervalSinceNow];
+        if (elapsedTime >= timeoutInterval) {
+            return NO; // Timeout
+        }
+
+        // You might need to add some delay here to avoid busy-waiting
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    return YES; // Successfully shutdown
+}
+
+- (void)eraseAndShutdownSimulator:(SimDevice *)device withError: (id *)error {
+    // Wait for Shutdown
+    BOOL didShutdown = [self waitForSimulatorShutdown:device];
+
+    if (didShutdown) {
+        NSLog(@"Simulator has been successfully shutdown.");
+    } else {
+        NSLog(@"Failed to shutdown simulator within the timeout, erase it.");
+        // Erase Simulator
+        [self eraseSimulator:device withError:error];
+    }
+}
+
+
+- (BOOL)shutdownSimulatorWithError:(id *)error {
+    [BPUtils printInfo:INFO withString:@"Starting Safe Shutdown of %@", self.device.UDID.UUIDString];
+
+    // Calling shutdown when already shutdown should be avoided (if detected).
+    if ([self.device.stateString isEqualToString:@"Shutdown"]) {
+        [BPUtils printInfo:INFO withString:@"Shutdown of %@ succeeded as it is already shutdown", self.device];
+        *error = nil;
+        return YES;
+    }
+
+    // Xcode 7 has a 'Creating' step that we should wait on before confirming the simulator is ready.
+    // On many occasions this is the case as we wait for the Simulator to be usable.
+    if ([self.device.stateString isEqualToString:@"Creating"]) {
+        [self eraseAndShutdownSimulator:self.device withError:error];
+        return YES;
+    }
+
+    // The error code for 'Unable to shutdown device in current state: Shutdown'
+    // can be safely ignored since these codes confirm that the simulator is already shutdown.
+    return [self.device shutdownWithError:error];
+}
+
 - (void)bootWithCompletion:(void (^)(NSError *error))completion {
     // Now boot it.
     [BPUtils printInfo:INFO withString:@"Booting a simulator without launching Simulator app"];
@@ -320,7 +384,8 @@
     [self.device bootAsyncWithOptions:options completionHandler:^(NSError *bootError){
         NSError *error = [self waitForDeviceReady];
         if (error) {
-            [self.device shutdownWithError:&error];
+//            [self.device shutdownWithError:&error];
+            [self shutdownSimulatorWithError:&error];
             if (error) {
                 [BPUtils printInfo:ERROR withString:@"Shutting down Simulator failed: %@", [error localizedDescription]];
             }
@@ -571,7 +636,8 @@
     }
     if (self.device) {
         [BPUtils printInfo:INFO withString:@"Shutting down Simulator"];
-        [self.device shutdownWithError:&error];
+//        [self.device shutdownWithError:&error];
+        [self shutdownSimulatorWithError:&error];
         if (error) {
             [BPUtils printInfo:ERROR withString:@"Shutting down Simulator failed: %@", [error localizedDescription]];
             completion(error, NO);


### PR DESCRIPTION
We were seeing lots of test timeout issues on macOS Ventura machines. It turned out that there's some shutdown error for simulators causing hanging bp processes. See below log for example:

```
{24164} 20230825.132813 [  ERROR ] (BP-1) Timeout: [Attempt 1] Create Simulator
{24164} 20230825.132813 [  ERROR ] (BP-1) The operation couldnâ€™t be completed. (org.linkedin.bluepill.ErrorDomain error -1.)
{24164} 20230825.132813 [  INFO  ] (BP-1) Relaunching the simulator due to a BAD STATE
{24164} 20230825.132813 [  INFO  ] (BP-1) [Attempt 1] Delete Simulator
{24164} 20230825.132813 [  INFO  ] (BP-1) Shutting down Simulator
{24164} 20230825.132859 [  INFO  ] (BP-1) Simulator 0F53DAFD-72C0-4B9C-8DA0-6975202DBB28 achieved the BOOTED state Booted
{24164} 20230825.132900 [  INFO  ] (BP-1) Completed: [Attempt 1] Delete Simulator 0F53DAFD-72C0-4B9C-8DA0-6975202DBB28
{24164} 20230825.132900 [  ERROR ] (BP-1) EndTimerFailure: EndTimer called without starting a timer for 'Simulator 0F53DAFD-72C0-4B9C-8DA0-6975202DBB28'
{24164} 20230825.132900 [  INFO  ] (BP-1) [Attempt 1] Create Simulator
{24164} 20230825.132900 [  INFO  ] (BP-1) Booting a simulator without launching Simulator app
{24164} 20230825.133118 [  ERROR ] (BP-1) Simulator 354C7BB2-724C-4BEE-A966-29CF01B867B9 failed to boot. State: Shutdown
{24164} 20230825.133118 [  ERROR ] (BP-1) Shutting down Simulator failed: Unable to shutdown device in current state: Shutdown
{24164} 20230825.133118 [  ERROR ] (BP-1) Completed: [Attempt 1] Create Simulator 354C7BB2-724C-4BEE-A966-29CF01B867B9
{24164} 20230825.133118 [  ERROR ] (BP-1) Unable to boot the Simulator.
{24164} 20230825.133118 [  INFO  ] (BP-1) [Attempt 1] Delete Simulator
{24164} 20230825.133118 [  INFO  ] (BP-1) Shutting down Simulator
{24164} 20230825.133118 [  ERROR ] (BP-1) Shutting down Simulator failed: Unable to shutdown device in current state: Shutdown
{24164} 20230825.133118 [  ERROR ] (BP-1) Completed: [Attempt 1] Delete Simulator 354C7BB2-724C-4BEE-A966-29CF01B867B9
{24164} 20230825.133118 [  ERROR ] (BP-1) Unable to shutdown device in current state: Shutdown
{24164} 20230825.133118 [  INFO  ] (BP-1) Attempt's Exit Status: BPExitStatusSimulatorCreationFailed, Bundle exit status: BPExitStatusSimulatorCreationFailed
{24164} 20230825.133118 [  INFO  ] (BP-1) Exit Status: BPExitStatusSimulatorCreationFailed
{24164} 20230825.133118 [  INFO  ] (BP-1) Failure Tolerance: 1
{24164} 20230825.133118 [  INFO  ] (BP-1) Retry count: 1
{24164} 20230825.133118 [  INFO  ] (BP-1) Recovering from tooling problem
```

Fixing this by not calling the private shutdown api when the simulator is already in the shutdown state.