### PR TITLE
Xcode 15.1

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -29,8 +29,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -48,8 +48,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh runner_tests
       - name: Capture xcresult files

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -6,12 +6,12 @@ jobs:
   # First machine, runs BP tests batch 1
   integration_tests1:
     name: Instance Test 1
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -25,12 +25,12 @@ jobs:
   # Second machine, runs BP tests batch 2
   integration_tests2:
     name: Instance Test 2
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -44,12 +44,12 @@ jobs:
   # Third machine, runs Bluepill tests and makes release build
   build:
     name: Bluepill Test and build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh runner_tests
       - name: Capture xcresult files

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -41,7 +41,26 @@ jobs:
           path: build/**/*.xcresult
           retention-days: 14
 
-  # Third machine, runs Bluepill tests and makes release build
+  # Third machine, runs BP tests batch 3
+  integration_tests3:
+    name: Instance Test 3
+    runs-on: macos-13
+    steps:
+      # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
+      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
+      - name: Run Bluepill tests
+        run: ./scripts/bluepill.sh instance_tests3
+      - name: Capture xcresult files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcresults-bp-tests2
+          path: build/**/*.xcresult
+          retention-days: 14
+
+  # Fourth machine, runs Bluepill tests and makes release build
   build:
     name: Bluepill Test and build
     runs-on: macos-13

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,12 +11,12 @@ jobs:
   # First machine, runs BP tests batch 1
   integration_tests1:
     name: Instance Test 1
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -30,12 +30,12 @@ jobs:
   # Second machine, runs BP tests batch 2
   integration_tests2:
     name: Instance Test 2
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -49,12 +49,12 @@ jobs:
   # Third machine, runs Bluepill tests and makes release build
   build:
     name: Bluepill Test and build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh runner_tests
       - name: Capture xcresult files

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -34,8 +34,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -53,8 +53,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh runner_tests
       - name: Capture xcresult files

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,7 +46,26 @@ jobs:
           path: build/**/*.xcresult
           retention-days: 14
 
-  # Third machine, runs Bluepill tests and makes release build
+  # Third machine, runs BP tests batch 3
+  integration_tests3:
+    name: Instance Test 3
+    runs-on: macos-13
+    steps:
+      # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
+      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
+      - name: Run Bluepill tests
+        run: ./scripts/bluepill.sh instance_tests3
+      - name: Capture xcresult files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcresults-bp-tests2
+          path: build/**/*.xcresult
+          retention-days: 14
+
+  # Fourth machine, runs Bluepill tests and makes release build
   build:
     name: Bluepill Test and build
     runs-on: macos-13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -32,8 +32,8 @@ jobs:
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 15.0
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -54,8 +54,8 @@ jobs:
     - name: Report event trigger data
       run: |
         echo "Event ${{ github.event_name }}, ref: ${{ github.ref }}"
-    - name: Select Xcode 15.0
-      run: sudo xcode-select -s /Applications/Xcode_15.0.app
+    - name: Select Xcode 15.1
+      run: sudo xcode-select -s /Applications/Xcode_15.1.app
     - name: Run Bluepill tests
       run: ./scripts/bluepill.sh runner_tests
     - name: Capture xcresult files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ jobs:
   # First machine, runs BP tests batch 1
   integration_tests1:
     name: Instance Test 1
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests1
       - name: Capture xcresult files
@@ -28,12 +28,12 @@ jobs:
   # Second machine, runs BP tests batch 2
   integration_tests2:
     name: Instance Test 2
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
       - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
-      - name: Select Xcode 14.0
-        run: sudo xcode-select -s /Applications/Xcode_14.0.app
+      - name: Select Xcode 15.0
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Run Bluepill tests
         run: ./scripts/bluepill.sh instance_tests2
       - name: Capture xcresult files
@@ -47,15 +47,15 @@ jobs:
   # Third machine, runs Bluepill tests and makes release build
   build:
     name: BP Test and build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     # actions/checkout@v2 but we use the sha because tags can be rewritten in git
     - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Report event trigger data
       run: |
         echo "Event ${{ github.event_name }}, ref: ${{ github.ref }}"
-    - name: Select Xcode 14.0
-      run: sudo xcode-select -s /Applications/Xcode_14.0.app
+    - name: Select Xcode 15.0
+      run: sudo xcode-select -s /Applications/Xcode_15.0.app
     - name: Run Bluepill tests
       run: ./scripts/bluepill.sh runner_tests
     - name: Capture xcresult files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,26 @@ jobs:
           path: build/**/*.xcresult
           retention-days: 14
 
-  # Third machine, runs Bluepill tests and makes release build
+  # Third machine, runs BP tests batch 3
+  integration_tests3:
+    name: Instance Test 3
+    runs-on: macos-13
+    steps:
+      # actions/checkout@v2 but we use the SHA1 because tags can be re-written in git
+      - uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      - name: Select Xcode 15.1
+        run: sudo xcode-select -s /Applications/Xcode_15.1.app
+      - name: Run Bluepill tests
+        run: ./scripts/bluepill.sh instance_tests3
+      - name: Capture xcresult files
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcresults-bp-tests2
+          path: build/**/*.xcresult
+          retention-days: 14
+
+  # Fourth machine, runs Bluepill tests and makes release build
   build:
     name: BP Test and build
     runs-on: macos-13

--- a/bluepill/bluepill.xcodeproj/project.pbxproj
+++ b/bluepill/bluepill.xcodeproj/project.pbxproj
@@ -359,9 +359,11 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				DSTROOT = "";
 				FRAMEWORK_SEARCH_PATHS = /Library/Developer/PrivateFrameworks/;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/..\"";
 				INFOPLIST_FILE = tests/Info.plist;
+				INSTALL_ROOT = /;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = LI.BluepillRunnerTests;
@@ -376,9 +378,11 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				DSTROOT = "";
 				FRAMEWORK_SEARCH_PATHS = /Library/Developer/PrivateFrameworks/;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/..\"";
 				INFOPLIST_FILE = tests/Info.plist;
+				INSTALL_ROOT = /;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = LI.BluepillRunnerTests;

--- a/bp/bp.xcodeproj/project.pbxproj
+++ b/bp/bp.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		018D5C1025B4FF4200B0314B /* BPIntTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPIntTestCase.h; sourceTree = "<group>"; };
 		018D5C1125B4FF4200B0314B /* BPIntTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPIntTestCase.m; sourceTree = "<group>"; };
 		018D5C1C25B6696000B0314B /* BPReportTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BPReportTests.m; sourceTree = "<group>"; };
+		71D4D0F82AEA1B4F00859482 /* SimDeviceBootInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimDeviceBootInfo.h; sourceTree = "<group>"; };
 		7A202A3D1DAED04900D935E3 /* BPExitStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BPExitStatus.h; sourceTree = "<group>"; };
 		7A202A3F1DB0066100D935E3 /* BPWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPWriter.h; sourceTree = "<group>"; };
 		7A202A401DB0066100D935E3 /* BPWriter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPWriter.m; sourceTree = "<group>"; };
@@ -527,6 +528,7 @@
 				BA954F651D6D1AB3007D011D /* NSString-SIMPackedVersion.h */,
 				BA954F671D6D1AB3007D011D /* NSUserDefaults-SimDefaults.h */,
 				BA954F681D6D1AB3007D011D /* SimDevice.h */,
+				71D4D0F82AEA1B4F00859482 /* SimDeviceBootInfo.h */,
 				BA954F691D6D1AB3007D011D /* SimDeviceIO.h */,
 				BA954F6A1D6D1AB3007D011D /* SimDeviceIOClient.h */,
 				BA954F6B1D6D1AB3007D011D /* SimDeviceIOInterface-Protocol.h */,
@@ -1017,6 +1019,7 @@
 			buildSettings = {
 				DEPLOYMENT_LOCATION = NO;
 				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
+				DSTROOT = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"/Library/Developer/PrivateFrameworks\"",
 					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
@@ -1031,6 +1034,7 @@
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/src/Info.plist";
+				INSTALL_ROOT = /;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DBP_USE_PRIVATE_FRAMEWORKS";
 				OTHER_LDFLAGS = (
@@ -1056,6 +1060,7 @@
 			buildSettings = {
 				DEPLOYMENT_LOCATION = NO;
 				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks/;
+				DSTROOT = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"/Library/Developer/PrivateFrameworks\"",
 					"\"$(PRIVATE_FRAMEWORKS_DIR)\"",
@@ -1070,6 +1075,7 @@
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/src/Info.plist";
+				INSTALL_ROOT = /;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DBP_USE_PRIVATE_FRAMEWORKS";
 				OTHER_LDFLAGS = (
@@ -1106,6 +1112,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks;
+				DSTROOT = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
@@ -1115,6 +1122,7 @@
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/src/Info.plist";
+				INSTALL_ROOT = /;
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
@@ -1143,6 +1151,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				"DEVELOPER_PRIVATE_FRAMEWORKS_DIR[arch=*]" = /Library/Developer/PrivateFrameworks;
+				DSTROOT = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
@@ -1152,6 +1161,7 @@
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/src/Info.plist";
+				INSTALL_ROOT = /;
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "";
@@ -1169,17 +1179,17 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				DSTROOT = "";
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/..",
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = tests/Info.plist;
+				INSTALL_ROOT = /;
 				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DBP_USE_PRIVATE_FRAMEWORKS";
 				OTHER_LDFLAGS = (
-					"-weak_framework",
-					DVTFoundation,
 					"-weak_framework",
 					CoreSimulator,
 					"-weak_framework",
@@ -1201,17 +1211,17 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = 57Y47U492U;
+				DSTROOT = "";
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/..",
 					"$(SRCROOT)/src",
 				);
 				INFOPLIST_FILE = tests/Info.plist;
+				INSTALL_ROOT = /;
 				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Library/PrivateFrameworks\"";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "-DBP_USE_PRIVATE_FRAMEWORKS";
 				OTHER_LDFLAGS = (
-					"-weak_framework",
-					DVTFoundation,
 					"-weak_framework",
 					CoreSimulator,
 					"-weak_framework",

--- a/bp/src/BPConfiguration.h
+++ b/bp/src/BPConfiguration.h
@@ -107,6 +107,7 @@ typedef NS_ENUM(NSInteger, BPProgram) {
 @property (nonatomic, strong) NSNumber *launchTimeout;
 @property (nonatomic, strong) NSNumber *deleteTimeout;
 @property (nonatomic) BOOL keepIndividualTestReports;
+@property (nonatomic, strong) NSNumber *testBundleDisconnectTimeout;
 
 @property (nonatomic, strong) NSArray<NSString *> *commandLineArguments; // command line arguments for the app
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *environmentVariables;

--- a/bp/src/BPConfiguration.m
+++ b/bp/src/BPConfiguration.m
@@ -150,6 +150,8 @@ struct BPOptions {
         "Directory where videos of test runs will be saved. If not provided, videos are not recorded."},
     {368, "keep-passing-videos", BLUEPILL_BINARY | BP_BINARY, NO, NO, no_argument, "Off", BP_VALUE | BP_BOOL, "keepPassingVideos",
         "Whether recorded videos should be kept if the test passed. They are deleted by default."},
+    {369, "test-bundle-disconnect-timeout", BLUEPILL_BINARY | BP_BINARY, NO, NO, required_argument, "60", BP_VALUE | BP_INTEGER, "testBundleDisconnectTimeout",
+        "The maximum amount of time, in seconds, to wait while a test bundle is disconnected but might still generate output."},
     {0, 0, 0, 0, 0, 0, 0}
 };
 

--- a/bp/src/BPConstants.h
+++ b/bp/src/BPConstants.h
@@ -10,9 +10,9 @@
 #import <Foundation/Foundation.h>
 
 #pragma mark - Version Constants
-#define BP_DEFAULT_XCODE_VERSION "15.0"
-#define BP_DEFAULT_RUNTIME "iOS 17.0"
-#define BP_DEFAULT_BASE_SDK "17.0"
+#define BP_DEFAULT_XCODE_VERSION "15.1"
+#define BP_DEFAULT_RUNTIME "iOS 17.2"
+#define BP_DEFAULT_BASE_SDK "17.2"
 
 #define BP_DEFAULT_DEVICE_TYPE "iPhone SE (3rd generation)"
 

--- a/bp/src/BPConstants.h
+++ b/bp/src/BPConstants.h
@@ -10,11 +10,11 @@
 #import <Foundation/Foundation.h>
 
 #pragma mark - Version Constants
-#define BP_DEFAULT_XCODE_VERSION "14.0"
-#define BP_DEFAULT_RUNTIME "iOS 16.0"
-#define BP_DEFAULT_BASE_SDK "16.0"
+#define BP_DEFAULT_XCODE_VERSION "15.0"
+#define BP_DEFAULT_RUNTIME "iOS 17.0"
+#define BP_DEFAULT_BASE_SDK "17.0"
 
-#define BP_DEFAULT_DEVICE_TYPE "iPhone 8"
+#define BP_DEFAULT_DEVICE_TYPE "iPhone SE (3rd generation)"
 
 #define BP_DAEMON_PROTOCOL_VERSION 26
 #define BP_MAX_PROCESSES_PERCENT 0.75

--- a/bp/src/BPTMDControlConnection.m
+++ b/bp/src/BPTMDControlConnection.m
@@ -85,13 +85,13 @@ static const NSString * const testManagerEnv = @"TESTMANAGERD_SIM_SOCK";
     DTXRemoteInvocationReceipt *receipt = [daemonProxy _IDE_initiateControlSessionForTestProcessID:@(self.testRunnerPid) protocolVersion:@(BP_TM_PROTOCOL_VERSION)];
     
     [receipt handleCompletion:^(NSNumber *version, NSError *error) {
+        self.connected = TRUE;
         if (error) {
             [BPUtils printInfo:ERROR withString:@"Error with daemon connection: %@", error];
             return;
         }
         NSInteger daemonProtocolVersion = version.integerValue;
         [BPUtils printInfo:INFO withString:@"Test manager daemon control session started (%ld)", (long)daemonProtocolVersion];
-        self.connected = TRUE;
     }];
 }
 
@@ -118,6 +118,7 @@ DTXConnection* connectToTestManager(SimDevice *device) {
     socklen_t length = (socklen_t)(strnlen(remote.sun_path, 1024) + sizeof(remote.sun_family) + sizeof(remote.sun_len));
     if (connect(socketFD, (struct sockaddr *)&remote, length) == -1) {
         [BPUtils printInfo:ERROR withString:@"ERROR connecting socket"];
+        close(socketFD);
     }
     DTXTransport *transport = [[objc_lookUpClass("DTXSocketTransport") alloc] initWithConnectedSocket:socketFD disconnectAction:^{
         [BPUtils printInfo:INFO withString:@"DTXSocketTransport disconnected"];

--- a/bp/src/BPTMDRunnerConnection.h
+++ b/bp/src/BPTMDRunnerConnection.h
@@ -17,6 +17,7 @@
 @end
 
 @interface BPTMDRunnerConnection : NSObject
+@property (nonatomic, assign) BOOL disconnected;
 @property (nonatomic, strong) BPExecutionContext *context;
 @property (nonatomic, strong) BPSimulator *simulator;
 @property (nonatomic, copy) void (^completionBlock)(NSError *, pid_t);

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -449,7 +449,7 @@ static int checkDisconnectDelay = 0;
     
     [runnerConnection startTestPlan];
 
-    checkDisconnectDelay = 1200;
+    checkDisconnectDelay = [self.config.testBundleDisconnectTimeout intValue];
     NEXT([self checkProcessWithContext:context conenction:runnerConnection]);
 
 }
@@ -485,7 +485,7 @@ static int checkDisconnectDelay = 0;
     }
 
     if (connection.disconnected) {
-        // wait for xx seconds to see if it can be finished
+        // break early if possible
         if (checkDisconnectDelay > 0) {
             checkDisconnectDelay --;
         } else {

--- a/bp/src/Bluepill.m
+++ b/bp/src/Bluepill.m
@@ -40,6 +40,8 @@ static void onInterrupt(int ignore) {
     interrupted = 1;
 }
 
+static int checkDisconnectDelay = 0;
+
 @interface Bluepill()<BPTestBundleConnectionDelegate>
 
 @property (nonatomic, strong) BPConfiguration *config;
@@ -309,6 +311,7 @@ static void onInterrupt(int ignore) {
     };
 
     handler.onError = ^(NSError *error) {
+        [[BPStats sharedStats] startTimer:SIMULATOR_LIFETIME(context.runner.UDID) atTime:simStart];
         [[BPStats sharedStats] addSimulatorCreateFailure];
         [BPUtils printInfo:ERROR withString:@"%@", [error localizedDescription]];
         // If we failed to create the simulator, there's no reason for us to try to delete it, which can just cause more issues
@@ -445,10 +448,12 @@ static void onInterrupt(int ignore) {
     [runnerConnection connectWithTimeout:180];
     
     [runnerConnection startTestPlan];
-    NEXT([self checkProcessWithContext:context]);
+
+    checkDisconnectDelay = 1200;
+    NEXT([self checkProcessWithContext:context conenction:runnerConnection]);
 
 }
-- (void)checkProcessWithContext:(BPExecutionContext *)context {
+- (void)checkProcessWithContext:(BPExecutionContext *)context conenction:(BPTMDRunnerConnection*)connection {
     BOOL isRunning = [self isProcessRunningWithContext:context];
     if (!isRunning && [context.runner isFinished]) {
         [BPUtils printInfo:INFO withString:@"Finished"];
@@ -479,7 +484,17 @@ static void onInterrupt(int ignore) {
         return;
     }
 
-    NEXT_AFTER(1, [self checkProcessWithContext:context]);
+    if (connection.disconnected) {
+        // wait for xx seconds to see if it can be finished
+        if (checkDisconnectDelay > 0) {
+            checkDisconnectDelay --;
+        } else {
+            [BPUtils printInfo:INFO withString:@"Connection disconnected, deleteing simulator"];
+            [self deleteSimulatorWithContext:context andStatus:BPExitStatusLaunchAppFailed];
+            return;
+        }
+    }
+    NEXT_AFTER(1, [self checkProcessWithContext:context conenction:connection]);
 }
 
 - (BOOL)isProcessRunningWithContext:(BPExecutionContext *)context {

--- a/bp/src/PrivateHeaders/CoreSimulator/SimDeviceBootInfo.h
+++ b/bp/src/PrivateHeaders/CoreSimulator/SimDeviceBootInfo.h
@@ -4,9 +4,17 @@
 //     class-dump is Copyright (C) 1997-1998, 2000-2001, 2004-2013 by Steve Nygard.
 //
 
-#import "NSObject.h"
+#import <Foundation/Foundation.h>
 
-#import "NSSecureCoding.h"
+
+typedef NS_ENUM(NSUInteger, SimDeviceBootInfoStatus) {
+  SimDeviceBootInfoStatusBooting = 0,
+  SimDeviceBootInfoStatusWaitingOnBackboard = 1,
+  SimDeviceBootInfoStatusWaitingOnDataMigration = 2,
+  SimDeviceBootInfoStatusDataMigrationFailed = 3,
+  SimDeviceBootInfoStatusWaitingOnSystemApp = 4,
+  SimDeviceBootInfoStatusFinished = 4294967295,
+};
 
 @class NSDictionary, NSString;
 
@@ -23,7 +31,6 @@
 @property(nonatomic) BOOL isTerminalStatus; // @synthesize isTerminalStatus=_isTerminalStatus;
 @property(nonatomic) double bootElapsedTime; // @synthesize bootElapsedTime=_bootElapsedTime;
 @property(nonatomic) unsigned int status; // @synthesize status=_status;
-- (void).cxx_destruct;
 @property(readonly, nonatomic) double migrationElapsedTime;
 @property(readonly, nonatomic) NSString *migrationPhaseDescription;
 - (void)encodeWithCoder:(id)arg1;

--- a/bp/tests/BluepillTests.m
+++ b/bp/tests/BluepillTests.m
@@ -195,6 +195,7 @@
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.testCasesToSkip = @[@"BPSampleAppTests/testCase000"];
+    self.config.errorRetriesCount = @1;
 
     BPExitStatus exitCode = [[[Bluepill alloc ] initWithConfiguration:self.config] run];
     XCTAssert(exitCode == BPExitStatusAllTestsPassed);
@@ -206,6 +207,7 @@
     self.config.failureTolerance = @0;
     self.config.testCaseTimeout = @10;
     self.config.testCasesToRun = @[@"BPAppNegativeTests/testBPDoesNotHangWithBigOutput"];
+    self.config.errorRetriesCount = @1;
     NSString *tempDir = NSTemporaryDirectory();
     NSError *error;
     NSString *outputDir = [BPUtils mkdtemp:[NSString stringWithFormat:@"%@/AppFailingTestsSetTempDir", tempDir] withError:&error];
@@ -221,6 +223,7 @@
     NSString *testBundlePath = [BPTestHelper sampleAppCrashingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.keepSimulator = YES;
+    self.config.errorRetriesCount = @1;
 
     Bluepill *bp = [[Bluepill alloc ] initWithConfiguration:self.config];
     BPExitStatus exitCode = [bp run];
@@ -276,6 +279,7 @@
     [BPUtils enableDebugOutput:YES];
     // The delay of ui test bootstrapping is larger than 5s.
     self.config.testCaseTimeout = @300;
+    self.config.errorRetriesCount = @1;
     NSString *testBundlePath = [BPTestHelper sampleAppUITestBundlePath];
     NSString *testRunnerPath = [BPTestHelper sampleAppUITestRunnerPath];
     NSString *tempDir = NSTemporaryDirectory();
@@ -305,7 +309,7 @@
     NSURL *preferencesFile = bp.test_simulator.preferencesFile;
 
     NSDictionary *plist = [[NSDictionary alloc] initWithContentsOfURL:preferencesFile];
-    XCTAssertEqualObjects(@"en_CH", plist[@"AppleLocale"]);
+    XCTAssertEqualObjects(@"en_CN", plist[@"AppleLocale"]);
 
     self.config.deleteSimUDID = bp.test_simulatorUDID;
     XCTAssertNotNil(self.config.deleteSimUDID);

--- a/bp/tests/BluepillTests.m
+++ b/bp/tests/BluepillTests.m
@@ -29,8 +29,6 @@
 
 @implementation BluepillTests
 
-
-
 - (void)tearDown {
     [super tearDown];
 }
@@ -300,6 +298,7 @@
     NSString *testBundlePath = [BPTestHelper sampleAppBalancingTestsBundlePath];
     self.config.testBundlePath = testBundlePath;
     self.config.keepSimulator = YES;
+    self.config.errorRetriesCount = @1;
 
     Bluepill *bp = [[Bluepill alloc ] initWithConfiguration:self.config];
     BPExitStatus exitCode = [bp run];

--- a/bp/tests/Resource Files/simulator-preferences.plist
+++ b/bp/tests/Resource Files/simulator-preferences.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>AppleLocale</key>
-	<string>en_CH</string>
+	<string>en_CN</string>
 	<key>AppleLanguages</key>
 	<array>
 		<string>en</string>

--- a/scripts/bluepill.sh
+++ b/scripts/bluepill.sh
@@ -107,12 +107,17 @@ run_tests() {
 
 bluepill_instance_tests1()
 {
-  run_tests bp "-skip-testing bp-tests/BPReportTests"
+  run_tests bp "-skip-testing bp-tests/BPReportTests1 -skip-testing bp-tests/BPReportTests2"
 }
 
 bluepill_instance_tests2()
 {
-  run_tests bp "-only-testing bp-tests/BPReportTests"
+  run_tests bp "-only-testing bp-tests/BPReportTests1"
+}
+
+bluepill_instance_tests3()
+{
+  run_tests bp "-only-testing bp-tests/BPReportTests2"
 }
 
 bluepill_runner_tests()


### PR DESCRIPTION
Support Xcode 15.1

- Since Xcode 15, the simulator eats up more machine resources. So made sure we boot and delete the simulators correctly with better status check
- Increased test bundle connection timeout to address the performance issue
- There are cases where a test bundle disconnects but bp keeps waiting to check for some output. Added a timeout config (`testBundleDisconnectTimeout`) to address that
- Made sure to call new private delegate functions 
- Added a new test batch to account for slower test run in Xcode 15.